### PR TITLE
Feature: archive query

### DIFF
--- a/migrations/0001_allow_delete_query.py
+++ b/migrations/0001_allow_delete_query.py
@@ -1,0 +1,12 @@
+from playhouse.migrate import Migrator
+from redash import db
+from redash import models
+
+if __name__ == '__main__':
+    db.connect_db()
+    migrator = Migrator(db.database)
+    
+    with db.database.transaction():
+        migrator.add_column(models.Query, models.Query.is_archived, 'is_archived')
+
+    db.close_db(None)

--- a/migrations/0001_allow_delete_query.py
+++ b/migrations/0001_allow_delete_query.py
@@ -1,5 +1,5 @@
 from playhouse.migrate import Migrator
-from redash import db
+from redash.models import db
 from redash import models
 
 if __name__ == '__main__':

--- a/rd_ui/app/index.html
+++ b/rd_ui/app/index.html
@@ -17,6 +17,7 @@
     <link rel="stylesheet" href="/bower_components/select2/select2.css">
     <link rel="stylesheet" href="/bower_components/angular-ui-select/dist/select.css">
     <link rel="stylesheet" href="/bower_components/pace/themes/pace-theme-minimal.css">
+    <link rel="stylesheet" href="/bower_components/font-awesome/css/font-awesome.css">
     <link rel="stylesheet" href="/styles/redash.css">
     <!-- endbuild -->
 </head>

--- a/rd_ui/app/scripts/controllers/query_view.js
+++ b/rd_ui/app/scripts/controllers/query_view.js
@@ -68,6 +68,29 @@
       $scope.queryResult.cancelExecution();
       Events.record(currentUser, 'cancel_execute', 'query', $scope.query.id);
     };
+    
+    $scope.deleteQuery = function(options, data) {
+      if (data) {
+        data.id = $scope.query.id;
+      } else {
+        data = $scope.query;
+      }
+      
+      $scope.isDirty = false;
+      
+      options = _.extend({}, {
+        successMessage: 'Query deleted',
+        errorMessage: 'Query could not be deleted'
+      }, options);
+      
+      return Query.delete({id: data.id}, function() {
+        growl.addSuccessMessage(options.successMessage);
+          $('#delete-confirmation-modal').modal('hide');
+          $location.path('/queries');
+        }, function(httpResponse) {
+          growl.addErrorMessage(options.errorMessage);
+        }).$promise;
+    }
 
     $scope.updateDataSource = function() {
       Events.record(currentUser, 'update_data_source', 'query', $scope.query.id);

--- a/rd_ui/app/scripts/controllers/query_view.js
+++ b/rd_ui/app/scripts/controllers/query_view.js
@@ -69,7 +69,7 @@
       Events.record(currentUser, 'cancel_execute', 'query', $scope.query.id);
     };
     
-    $scope.deleteQuery = function(options, data) {
+    $scope.archiveQuery = function(options, data) {
       if (data) {
         data.id = $scope.query.id;
       } else {
@@ -79,14 +79,16 @@
       $scope.isDirty = false;
       
       options = _.extend({}, {
-        successMessage: 'Query deleted',
-        errorMessage: 'Query could not be deleted'
+        successMessage: 'Query archived',
+        errorMessage: 'Query could not be archived'
       }, options);
       
       return Query.delete({id: data.id}, function() {
+        $scope.query.is_archived = true;
+        $scope.query.ttl = -1;
         growl.addSuccessMessage(options.successMessage);
-          $('#delete-confirmation-modal').modal('hide');
-          $location.path('/queries');
+          // This feels dirty.
+          $('#archive-confirmation-modal').modal('hide');
         }, function(httpResponse) {
           growl.addErrorMessage(options.errorMessage);
         }).$promise;

--- a/rd_ui/app/views/query.html
+++ b/rd_ui/app/views/query.html
@@ -1,6 +1,7 @@
 
 <div class="container">
 
+    <p class="alert alert-warning" ng-if="query.is_archived">This query is archived and can't be used in dashboards, and won't appear in search results.</p>
     <alert-unsaved-changes ng-if="canEdit" is-dirty="isDirty"></alert-unsaved-changes>
 
     <div class="row">
@@ -133,25 +134,25 @@
                     <span class="glyphicon glyphicon-cloud-download"></span>
                     <span class="rd-hidden-xs">Download Dataset</span>
                 </a>
-            </p>
-            <p ng-show="query.id != undefined && (isQueryOwner || currentUser.hasPermission('delete_queries'))">
-                <a class="btn btn-danger btn-sm" ng-disabled="queryExecuting" data-toggle="modal" data-target="#delete-confirmation-modal">
-                    <span class="glyphicon glyphicon-remove"></span>
-                    <span class="rd-hidden-xs">Delete query</span>
+
+                <a class="btn btn-warning btn-sm" ng-disabled="queryExecuting" data-toggle="modal" data-target="#archive-confirmation-modal"
+                   ng-show="!query.is_archived && query.id != undefined && (isQueryOwner || currentUser.hasPermission('admin'))">
+                    <i class="fa fa-archive" title="Archive Query"></i>
                 </a>
                 
-                <div class="modal fade" id="delete-confirmation-modal" tabindex="-1" role="dialog" aria-labelledby="deleteConfirmationModal" aria-hidden="true">
+                <div class="modal fade" id="archive-confirmation-modal" tabindex="-1" role="dialog" aria-labelledby="archiveConfirmationModal" aria-hidden="true">
                   <div class="modal-dialog">
                     <div class="modal-content">
                       <div class="modal-header">
-                        <h4 class="modal-title">Query deletion</h4>
+                        <h4 class="modal-title">Query Archive</h4>
                       </div>
                       <div class="modal-body">
-                        Are you sure you want to delete the query?
+                        Are you sure you want to archive this query? <br/>
+                        All dashboard widgets created with its visualizations will be deleted.
                       </div>
                       <div class="modal-footer">
                         <button type="button" class="btn btn-default" data-dismiss="modal">No</button>
-                        <button type="button" class="btn btn-primary" ng-click="deleteQuery()">Yes, delete!</button>
+                        <button type="button" class="btn btn-primary" ng-click="archiveQuery()">Yes, archive.</button>
                       </div>
                     </div>
                   </div>

--- a/rd_ui/app/views/query.html
+++ b/rd_ui/app/views/query.html
@@ -134,6 +134,29 @@
                     <span class="rd-hidden-xs">Download Dataset</span>
                 </a>
             </p>
+            <p ng-show="query.id != undefined && (isQueryOwner || currentUser.hasPermission('delete_queries'))">
+                <a class="btn btn-danger btn-sm" ng-disabled="queryExecuting" data-toggle="modal" data-target="#delete-confirmation-modal">
+                    <span class="glyphicon glyphicon-remove"></span>
+                    <span class="rd-hidden-xs">Delete query</span>
+                </a>
+                
+                <div class="modal fade" id="delete-confirmation-modal" tabindex="-1" role="dialog" aria-labelledby="deleteConfirmationModal" aria-hidden="true">
+                  <div class="modal-dialog">
+                    <div class="modal-content">
+                      <div class="modal-header">
+                        <h4 class="modal-title">Query deletion</h4>
+                      </div>
+                      <div class="modal-body">
+                        Are you sure you want to delete the query?
+                      </div>
+                      <div class="modal-footer">
+                        <button type="button" class="btn btn-default" data-dismiss="modal">No</button>
+                        <button type="button" class="btn btn-primary" ng-click="deleteQuery()">Yes, delete!</button>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+            </p>
         </div>
 
         <div class="col-lg-9">

--- a/rd_ui/bower.json
+++ b/rd_ui/bower.json
@@ -26,7 +26,8 @@
     "marked": "~0.3.2",
     "bucky": "~0.2.6",
     "pace": "~0.5.1",
-    "angular-ui-select": "0.8.2"
+    "angular-ui-select": "0.8.2",
+    "font-awesome": "~4.2.0"
   },
   "devDependencies": {
     "angular-mocks": "1.2.18",

--- a/redash/__init__.py
+++ b/redash/__init__.py
@@ -5,7 +5,7 @@ from statsd import StatsClient
 
 from redash import settings
 
-__version__ = '0.4.0'
+__version__ = '0.5.0'
 
 
 def setup_logging():

--- a/redash/models.py
+++ b/redash/models.py
@@ -77,7 +77,7 @@ class ApiUser(UserMixin):
 
 class Group(BaseModel):
     DEFAULT_PERMISSIONS = ['create_dashboard', 'create_query', 'edit_dashboard', 'edit_query',
-                           'view_query', 'view_source', 'execute_query']
+                           'view_query', 'view_source', 'execute_query', 'delete_query']
 
     id = peewee.PrimaryKeyField()
     name = peewee.CharField(max_length=100)
@@ -283,6 +283,7 @@ class Query(BaseModel):
     ttl = peewee.IntegerField()
     user_email = peewee.CharField(max_length=360, null=True)
     user = peewee.ForeignKeyField(User)
+    is_archived = peewee.BooleanField(default=False, index=True)
     created_at = peewee.DateTimeField(default=datetime.datetime.now)
 
     class Meta:
@@ -304,6 +305,7 @@ class Query(BaseModel):
             'query_hash': self.query_hash,
             'ttl': self.ttl,
             'api_key': self.api_key,
+            'is_archived': self.is_archived,
             'created_at': self.created_at,
             'data_source_id': self._data.get('data_source', None)
         }
@@ -422,6 +424,7 @@ class Dashboard(BaseModel):
         if with_widgets:
             widgets = Widget.select(Widget, Visualization, Query, User)\
                 .where(Widget.dashboard == self.id)\
+                .where(Query.is_archived == False)\
                 .join(Visualization, join_type=peewee.JOIN_LEFT_OUTER)\
                 .join(Query, join_type=peewee.JOIN_LEFT_OUTER)\
                 .join(User, join_type=peewee.JOIN_LEFT_OUTER)
@@ -544,7 +547,7 @@ class Widget(BaseModel):
             d['visualization'] = self.visualization.to_dict()
 
         return d
-
+    
     def __unicode__(self):
         return u"%s" % self.id
 
@@ -598,5 +601,9 @@ def create_db(create_tables, drop_tables):
 
         if create_tables and not model.table_exists():
             model.create_table()
+    
+    Group.insert(name='admin', permissions=['admin'], tables=['*']).execute()
+    Group.insert(name='api', permissions=['view_query'], tables=['*']).execute()
+    Group.insert(name='default', permissions=Group.DEFAULT_PERMISSIONS, tables=['*']).execute()
 
     db.close_db(None)

--- a/redash/permissions.py
+++ b/redash/permissions.py
@@ -10,10 +10,7 @@ class require_permissions(object):
     def __call__(self, fn):
         @functools.wraps(fn)
         def decorated(*args, **kwargs):
-            has_permissions = reduce(lambda a, b: a and b,
-                                      map(lambda permission: permission in current_user.permissions,
-                                          self.permissions),
-                                      True)
+            has_permissions = current_user.has_permissions(self.permissions)
 
             if has_permissions:
                 return fn(*args, **kwargs)

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -60,6 +60,7 @@ query_factory = ModelFactory(redash.models.Query,
                              query='SELECT 1',
                              ttl=-1,
                              user=user_factory.create,
+                             is_archived=False,
                              data_source=data_source_factory.create)
 
 query_result_factory = ModelFactory(redash.models.QueryResult,


### PR DESCRIPTION
Archiving query will remove all widgets created based on its visualizations. Currently its a one way ticket -- you can only archive a query. Based on need, we might add un-archive option.

Note: **migration needed**.

This is a refactor of @christophervalles work in #215.