### PR TITLE
Fix #263: timestamp fields should be with time zone

### DIFF
--- a/migrations/0002_fix_timestamp_fields.py
+++ b/migrations/0002_fix_timestamp_fields.py
@@ -1,0 +1,21 @@
+from redash.models import db
+
+if __name__ == '__main__':
+    db.connect_db()
+    columns = (
+        ('activity_log', 'created_at'),
+        ('dashboards', 'created_at'),
+        ('data_sources', 'created_at'),
+        ('events', 'created_at'),
+        ('groups', 'created_at'),
+        ('queries', 'created_at'),
+        ('widgets', 'created_at'),
+        ('query_results', 'retrieved_at')
+    )
+
+    with db.database.transaction():
+        for column in columns:
+            db.database.execute_sql("ALTER TABLE {} ALTER COLUMN {} TYPE timestamp with time zone;".format(*column))
+
+    db.close_db(None)
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ Werkzeug==0.9.4
 aniso8601==0.82
 blinker==1.3
 itsdangerous==0.23
-peewee==2.2.2
+peewee==2.4.7
 psycopg2==2.5.2
 python-dateutil==2.1
 pytz==2013.9


### PR DESCRIPTION
Until now all timestamp fields were created as "timestamp without time zone", which resulted in wrong time stamps shown in view. This fixes the model definitions and adds a migration to fix existing installations.