### PR TITLE
Fix: make the data_sources' name unique

### DIFF
--- a/migrations/0007_make_ds_name_unique.py
+++ b/migrations/0007_make_ds_name_unique.py
@@ -1,0 +1,12 @@
+from redash.models import db
+
+if __name__ == '__main__':
+    db.connect_db()
+
+    with db.database.transaction():
+        # Make sure all data sources names are unique.
+        db.database.execute_sql("""UPDATE data_sources SET name = name || ' ' || id;""")
+        # Add unique constraint on data_sources.name.
+        db.database.execute_sql("ALTER TABLE data_sources ADD CONSTRAINT unique_name UNIQUE (name);")
+
+    db.close_db(None)

--- a/redash/models.py
+++ b/redash/models.py
@@ -223,7 +223,7 @@ class ActivityLog(BaseModel):
 
 class DataSource(BaseModel):
     id = peewee.PrimaryKeyField()
-    name = peewee.CharField()
+    name = peewee.CharField(unique=True)
     type = peewee.CharField()
     options = peewee.TextField()
     queue_name = peewee.CharField(default="queries")


### PR DESCRIPTION
Data_sources' name should be unique since it should be uniquely identified from the user interface, as well as when `sudo -u redash bin/run ./manage.py ds delete` is called.

Ref: https://github.com/EverythingMe/redash/issues/277