### PR TITLE
Feature: schema browser and simple autocomplete

### DIFF
--- a/rd_ui/app/index.html
+++ b/rd_ui/app/index.html
@@ -18,6 +18,7 @@
     <link rel="stylesheet" href="/bower_components/angular-ui-select/dist/select.css">
     <link rel="stylesheet" href="/bower_components/pace/themes/pace-theme-minimal.css">
     <link rel="stylesheet" href="/bower_components/font-awesome/css/font-awesome.css">
+    <link rel="stylesheet" href="/bower_components/codemirror/addon/hint/show-hint.css">
     <link rel="stylesheet" href="/styles/redash.css">
     <!-- endbuild -->
 </head>
@@ -105,9 +106,10 @@
 <script src="/bower_components/codemirror/lib/codemirror.js"></script>
 <script src="/bower_components/codemirror/addon/edit/matchbrackets.js"></script>
 <script src="/bower_components/codemirror/addon/edit/closebrackets.js"></script>
+<script src="/bower_components/codemirror/addon/hint/show-hint.js"></script>
+<script src="/bower_components/codemirror/addon/hint/anyword-hint.js"></script>
 <script src="/bower_components/codemirror/mode/sql/sql.js"></script>
 <script src="/bower_components/codemirror/mode/javascript/javascript.js"></script>
-<script src="/bower_components/angular-ui-codemirror/ui-codemirror.js"></script>
 <script src="/bower_components/highcharts/highcharts.js"></script>
 <script src="/bower_components/highcharts/modules/exporting.js"></script>
 <script src="/bower_components/gridster/dist/jquery.gridster.js"></script>

--- a/rd_ui/app/scripts/app.js
+++ b/rd_ui/app/scripts/app.js
@@ -6,7 +6,6 @@ angular.module('redash', [
     'redash.services',
     'redash.renderers',
     'redash.visualization',
-    'ui.codemirror',
     'highchart',
     'ui.select2',
     'angular-growl',

--- a/rd_ui/app/scripts/controllers/query_view.js
+++ b/rd_ui/app/scripts/controllers/query_view.js
@@ -19,6 +19,22 @@
     }
 
     $scope.query = $route.current.locals.query;
+
+    var updateSchema = function() {
+      $scope.hasSchema = false;
+      $scope.editorSize = "col-md-12";
+      var dataSourceId = $scope.query.data_source_id || $scope.dataSources[0].id;
+      $scope.schema = DataSource.getSchema({id: dataSourceId}, function(data) {
+        if (data && data.length > 0) {
+          $scope.editorSize = "col-md-9";
+          $scope.hasSchema = true;
+        } else {
+          $scope.hasSchema = false;
+          $scope.editorSize = "col-md-12";
+        }
+      });
+    }
+
     Events.record(currentUser, 'view', 'query', $scope.query.id);
     getQueryResult();
     $scope.queryExecuting = false;
@@ -27,6 +43,7 @@
     $scope.canViewSource = currentUser.hasPermission('view_source');
 
     $scope.dataSources = DataSource.get(function(dataSources) {
+      updateSchema();
       $scope.query.data_source_id = $scope.query.data_source_id || dataSources[0].id;
     });
 
@@ -126,6 +143,7 @@
         });
       }
 
+      updateSchema();
       $scope.executeQuery();
     };
 

--- a/rd_ui/app/scripts/controllers/query_view.js
+++ b/rd_ui/app/scripts/controllers/query_view.js
@@ -24,8 +24,13 @@
       $scope.hasSchema = false;
       $scope.editorSize = "col-md-12";
       var dataSourceId = $scope.query.data_source_id || $scope.dataSources[0].id;
-      $scope.schema = DataSource.getSchema({id: dataSourceId}, function(data) {
+      DataSource.getSchema({id: dataSourceId}, function(data) {
         if (data && data.length > 0) {
+          $scope.schema = data;
+          _.each(data, function(table) {
+            table.collapsed = true;
+          });
+
           $scope.editorSize = "col-md-9";
           $scope.hasSchema = true;
         } else {

--- a/rd_ui/app/scripts/directives/query_directives.js
+++ b/rd_ui/app/scripts/directives/query_directives.js
@@ -63,7 +63,8 @@
       restrict: 'E',
       scope: {
         'query': '=',
-        'lock': '='
+        'lock': '=',
+        'schema': '='
       },
       template: '<textarea></textarea>',
       link: {
@@ -79,10 +80,17 @@
             extraKeys: {"Ctrl-Space": "autocomplete"}
           };
 
+          var additionalHints = [];
+
           CodeMirror.commands.autocomplete = function(cm) {
             var hinter  = function(editor, options) {
               var hints = CodeMirror.hint.anyword(editor, options);
-//              hints.list.push('select', 'from', 'where');
+              var cur = editor.getCursor(), token = editor.getTokenAt(cur).string;
+
+              hints.list = _.union(hints.list, _.filter(additionalHints, function (h) {
+                return h.search(token) === 0;
+              }));
+
               return hints;
             };
 
@@ -105,6 +113,20 @@
           $scope.$watch('query.query', function () {
             if ($scope.query.query !== codemirror.getValue()) {
               codemirror.setValue($scope.query.query);
+            }
+          });
+
+          $scope.$watch('schema', function (schema) {
+            if (schema) {
+              var keywords = [];
+              _.each(schema, function (table) {
+                keywords.push(table.name);
+                _.each(table.columns, function (c) {
+                  keywords.push(c);
+                });
+              });
+
+              additionalHints = _.unique(keywords);
             }
           });
 

--- a/rd_ui/app/scripts/directives/query_directives.js
+++ b/rd_ui/app/scripts/directives/query_directives.js
@@ -69,7 +69,7 @@
       link: {
         pre: function ($scope, element) {
           var textarea = element.children()[0];
-          $scope.editorOptions = {
+          var editorOptions = {
             mode: 'text/x-sql',
             lineWrapping: true,
             lineNumbers: true,
@@ -80,10 +80,17 @@
           };
 
           CodeMirror.commands.autocomplete = function(cm) {
-            CodeMirror.showHint(cm, CodeMirror.hint.anyword);
+            var hinter  = function(editor, options) {
+              var hints = CodeMirror.hint.anyword(editor, options);
+//              hints.list.push('select', 'from', 'where');
+              return hints;
+            };
+
+//            CodeMirror.showHint(cm, CodeMirror.hint.anyword);
+            CodeMirror.showHint(cm, hinter);
           };
 
-          var codemirror = CodeMirror.fromTextArea(textarea, $scope.editorOptions);
+          var codemirror = CodeMirror.fromTextArea(textarea, editorOptions);
 
           codemirror.on('change', function(instance) {
             var newValue = instance.getValue();
@@ -95,7 +102,7 @@
             }
           });
 
-          $scope.$watch('query.query', function (newValue, oldValue) {
+          $scope.$watch('query.query', function () {
             if ($scope.query.query !== codemirror.getValue()) {
               codemirror.setValue($scope.query.query);
             }

--- a/rd_ui/app/scripts/directives/query_directives.js
+++ b/rd_ui/app/scripts/directives/query_directives.js
@@ -29,7 +29,7 @@
       restrict: 'E',
       template: '<span ng-show="query.id && canViewSource">\
                     <a ng-show="!sourceMode"\
-                      ng-href="{{query.id}}/source#{{selectedTab}}">Show Source\
+                      ng-href="/queries/{{query.id}}/source#{{selectedTab}}">Show Source\
                     </a>\
                     <a ng-show="sourceMode"\
                       ng-href="/queries/{{query.id}}#{{selectedTab}}">Hide Source\
@@ -68,19 +68,21 @@
       template: '<textarea\
                   ui-codemirror="editorOptions"\
                   ng-model="query.query">',
-      link: function($scope) {
-        $scope.editorOptions = {
+      link: {
+        pre: function ($scope) {
+          $scope.editorOptions = {
             mode: 'text/x-sql',
             lineWrapping: true,
             lineNumbers: true,
             readOnly: false,
             matchBrackets: true,
             autoCloseBrackets: true
-        };
+          };
 
-        $scope.$watch('lock', function(locked) {
-          $scope.editorOptions.readOnly = locked ? 'nocursor' : false;
-        });
+          $scope.$watch('lock', function (locked) {
+            $scope.editorOptions.readOnly = locked ? 'nocursor' : false;
+          });
+        },
       }
     }
   }

--- a/rd_ui/app/scripts/services/resources.js
+++ b/rd_ui/app/scripts/services/resources.js
@@ -480,7 +480,12 @@
 
 
   var DataSource = function ($resource) {
-    var DataSourceResource = $resource('/api/data_sources/:id', {id: '@id'}, {'get': {'method': 'GET', 'cache': true, 'isArray': true}});
+    var actions = {
+      'get': {'method': 'GET', 'cache': true, 'isArray': true},
+      'getSchema': {'method': 'GET', 'cache': true, 'isArray': true, 'url': '/api/data_sources/:id/schema'}
+    };
+
+    var DataSourceResource = $resource('/api/data_sources/:id', {id: '@id'}, actions);
 
     return DataSourceResource;
   }

--- a/rd_ui/app/styles/redash.css
+++ b/rd_ui/app/styles/redash.css
@@ -156,7 +156,7 @@ li.widget:hover {
 /* CodeMirror */
 .CodeMirror {
     border: 1px solid #eee;
-    height: auto;
+    /*height: auto;*/
     min-height: 300px;
     margin-bottom: 10px;
 }
@@ -306,6 +306,18 @@ counter-renderer counter-name {
 
 .iframe-container {
     height: 100%;
+}
+
+.schema-browser {
+    height: 300px;
+    overflow: scroll;
+}
+
+div.table-name {
+    overflow: scroll;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    cursor: pointer;
 }
 
 /*

--- a/rd_ui/app/views/query.html
+++ b/rd_ui/app/views/query.html
@@ -59,9 +59,9 @@
 
     <hr>
 
-    <div class="row">
-        <div class="col-lg-12">
-            <div ng-show="sourceMode">
+    <div class="row" ng-if="sourceMode">
+        <div ng-class="editorSize">
+            <div>
                 <p>
                     <button type="button" class="btn btn-primary btn-xs" ng-disabled="queryExecuting" ng-click="executeQuery()">
                         <span class="glyphicon glyphicon-play"></span> Execute
@@ -77,17 +77,25 @@
                         </button>
                     </span>
                 </p>
-            </div>
 
-            <!-- code editor -->
-            <div ng-if="sourceMode">
                 <p>
                     <query-editor query="query" lock="queryFormatting"></query-editor>
                 </p>
-                <hr>
             </div>
         </div>
-
+        <div class="col-md-3" ng-show="hasSchema">
+            <div>
+                <input type="text" placeholder="Search schema..." class="form-control" ng-model="schemaFilter">
+            </div>
+            <div style="height:300px; overflow: overlay;">
+                <div ng-repeat="table in schema | filter:schemaFilter">
+                    {{obj}}
+                    <div class="tree-toggler"><i class="fa fa-table"></i> <strong>{{table.name}}</strong></div>
+                    <div ng-repeat="column in table.columns | filter:schemaFilter" style="padding-left:16px;">{{column}}</div>
+                </div>
+            </div>
+        </div>
+        <hr>
     </div>
 
     <div class="row">

--- a/rd_ui/app/views/query.html
+++ b/rd_ui/app/views/query.html
@@ -79,7 +79,7 @@
                 </p>
 
                 <p>
-                    <query-editor query="query" lock="queryFormatting"></query-editor>
+                    <query-editor query="query" schema="schema" lock="queryFormatting"></query-editor>
                 </p>
             </div>
         </div>

--- a/rd_ui/app/views/query.html
+++ b/rd_ui/app/views/query.html
@@ -87,17 +87,21 @@
             <div>
                 <input type="text" placeholder="Search schema..." class="form-control" ng-model="schemaFilter">
             </div>
-            <div style="height:300px; overflow: overlay;">
+            <div class="schema-browser">
                 <div ng-repeat="table in schema | filter:schemaFilter">
-                    {{obj}}
-                    <div class="tree-toggler"><i class="fa fa-table"></i> <strong>{{table.name}}</strong></div>
-                    <div ng-repeat="column in table.columns | filter:schemaFilter" style="padding-left:16px;">{{column}}</div>
+                    <div class="table-name" ng-click="table.collapsed = !table.collapsed">
+                        <i class="fa fa-table"></i> <strong><span title="{{table.name}}">{{table.name}}</span></strong>
+                    </div>
+                    <div collapse="table.collapsed">
+                        <div ng-repeat="column in table.columns | filter:schemaFilter" style="padding-left:16px;">{{column}}</div>
+                    </div>
                 </div>
             </div>
         </div>
-        <hr>
-    </div>
 
+
+    </div>
+    <hr ng-if="sourceMode">
     <div class="row">
         <div class="col-lg-3 rd-hidden-xs">
             <p>
@@ -105,7 +109,7 @@
                 <span class="text-muted">Created By </span>
                 <strong>{{query.user.name}}</strong>
             </p>
-            <p ng-if="query.user.id != query.last_modified_by.id">
+            <p ng-if="query.last_modified_by && query.user.id != query.last_modified_by.id">
                 <span class="glyphicon glyphicon-user"></span>
                 <span class="text-muted">Last Modified By </span>
                 <strong>{{query.last_modified_by.name}}</strong>
@@ -198,7 +202,7 @@
                             <rd-tab tab-id="{{vis.id}}" name="{{vis.name}}" ng-if="vis.type!='TABLE'" ng-repeat="vis in query.visualizations">
                                 <span class="remove" ng-click="deleteVisualization($event, vis)" ng-show="canEdit"> &times;</span>
                             </rd-tab>
-                            <rd-tab tab-id="add" name="&plus; New" removeable="true" ng-show="canEdit"></rd-tab>
+                            <rd-tab tab-id="add" name="&plus; New Visualization" removeable="true" ng-show="canEdit"></rd-tab>
                             <li ng-if="!sourceMode" class="rd-tab-btn"><button class="btn btn-sm btn-default" ng-click="executeQuery()" ng-disabled="queryExecuting" title="Refresh Dataset"><span class="glyphicon glyphicon-refresh"></span></button></li>
                         </ul>
                     </div>

--- a/rd_ui/app/views/query.html
+++ b/rd_ui/app/views/query.html
@@ -80,7 +80,7 @@
             </div>
 
             <!-- code editor -->
-            <div ng-show="sourceMode">
+            <div ng-if="sourceMode">
                 <p>
                     <query-editor query="query" lock="queryFormatting"></query-editor>
                 </p>

--- a/rd_ui/bower.json
+++ b/rd_ui/bower.json
@@ -12,7 +12,7 @@
     "es5-shim": "2.0.8",
     "angular-moment": "0.2.0",
     "moment": "2.1.0",
-    "angular-ui-codemirror": "0.0.5",
+    "angular-ui-codemirror": "0.2.3",
     "highcharts": "3.0.10",
     "underscore": "1.5.1",
     "pivottable": "~1.1.1",

--- a/rd_ui/bower.json
+++ b/rd_ui/bower.json
@@ -12,7 +12,7 @@
     "es5-shim": "2.0.8",
     "angular-moment": "0.2.0",
     "moment": "2.1.0",
-    "angular-ui-codemirror": "0.2.3",
+    "codemirror": "4.8.0",
     "highcharts": "3.0.10",
     "underscore": "1.5.1",
     "pivottable": "~1.1.1",

--- a/redash/cache.py
+++ b/redash/cache.py
@@ -1,6 +1,3 @@
-from flask import make_response
-from functools import update_wrapper
-
 ONE_YEAR = 60 * 60 * 24 * 365.25
 
 headers = {

--- a/redash/controllers.py
+++ b/redash/controllers.py
@@ -22,7 +22,7 @@ from redash.wsgi import app, auth, api
 from redash.tasks import QueryTask, record_event
 from redash.cache import headers as cache_headers
 from redash.permissions import require_permission
-from redash.query_runner import query_runners, validate_configuration
+from redash.query_runner import query_runners, validate_configuration, get_query_runner
 
 
 @app.route('/ping', methods=['GET'])
@@ -219,9 +219,18 @@ class DataSourceListAPI(BaseResource):
 
         return datasource.to_dict()
 
-
 api.add_resource(DataSourceListAPI, '/api/data_sources', endpoint='data_sources')
 
+
+class DataSourceSchemaAPI(BaseResource):
+    def get(self, data_source_id):
+        data_source = models.DataSource.get_by_id(data_source_id)
+        query_runner = get_query_runner(data_source.type, data_source.options)
+        schema = query_runner.get_schema()
+
+        return schema
+
+api.add_resource(DataSourceSchemaAPI, '/api/data_sources/<data_source_id>/schema')
 
 class DashboardRecentAPI(BaseResource):
     def get(self):

--- a/redash/controllers.py
+++ b/redash/controllers.py
@@ -22,7 +22,7 @@ from redash.wsgi import app, auth, api
 from redash.tasks import QueryTask, record_event
 from redash.cache import headers as cache_headers
 from redash.permissions import require_permission
-from redash.query_runner import query_runners, validate_configuration, get_query_runner
+from redash.query_runner import query_runners, validate_configuration
 
 
 @app.route('/ping', methods=['GET'])
@@ -225,8 +225,7 @@ api.add_resource(DataSourceListAPI, '/api/data_sources', endpoint='data_sources'
 class DataSourceSchemaAPI(BaseResource):
     def get(self, data_source_id):
         data_source = models.DataSource.get_by_id(data_source_id)
-        query_runner = get_query_runner(data_source.type, data_source.options)
-        schema = query_runner.get_schema()
+        schema = data_source.get_schema()
 
         return schema
 

--- a/redash/models.py
+++ b/redash/models.py
@@ -251,7 +251,7 @@ class DataSource(BaseModel):
 
         if cache is None:
             query_runner = get_query_runner(self.type, self.options)
-            schema = query_runner.get_schema()
+            schema = sorted(query_runner.get_schema(), key=lambda t: t['name'])
 
             redis_connection.set(key, json.dumps(schema))
         else:

--- a/redash/query_runner/__init__.py
+++ b/redash/query_runner/__init__.py
@@ -57,6 +57,9 @@ class BaseQueryRunner(object):
     def run_query(self, query):
         raise NotImplementedError()
 
+    def get_schema(self):
+        return {}
+
     @classmethod
     def to_dict(cls):
         return {

--- a/redash/query_runner/__init__.py
+++ b/redash/query_runner/__init__.py
@@ -58,7 +58,7 @@ class BaseQueryRunner(object):
         raise NotImplementedError()
 
     def get_schema(self):
-        return {}
+        return []
 
     @classmethod
     def to_dict(cls):

--- a/redash/query_runner/pg.py
+++ b/redash/query_runner/pg.py
@@ -1,4 +1,3 @@
-from collections import defaultdict
 import json
 import logging
 import psycopg2

--- a/redash/query_runner/pg.py
+++ b/redash/query_runner/pg.py
@@ -86,7 +86,7 @@ class PostgreSQL(BaseQueryRunner):
 
     def get_schema(self):
         query = """
-        SELECT table_schema, table_name, column_name, data_type
+        SELECT table_schema, table_name, column_name
         FROM information_schema.columns
         WHERE table_schema NOT IN ('pg_catalog', 'information_schema');
         """
@@ -98,15 +98,19 @@ class PostgreSQL(BaseQueryRunner):
 
         results = json.loads(results)
 
-        schema = defaultdict(list)
+        schema = {}
         for row in results['rows']:
             if row['table_schema'] != 'public':
                 table_name = '{}.{}'.format(row['table_schema'], row['table_name'])
             else:
                 table_name = row['table_name']
-            schema[table_name].append({'name': row['column_name'], 'type': row['data_type']})
 
-        return schema
+            if table_name not in schema:
+                schema[table_name] = {'name': table_name, 'columns': []}
+
+            schema[table_name]['columns'].append(row['column_name'])
+
+        return schema.values()
 
     def run_query(self, query):
         connection = psycopg2.connect(self.connection_string, async=True)

--- a/redash/tasks.py
+++ b/redash/tasks.py
@@ -218,6 +218,17 @@ def cleanup_query_results():
     logger.info("Deleted %d unused query results out of total of %d." % (deleted_count, total_unused_query_results))
 
 
+@celery.task(base=BaseTask)
+def refresh_schemas():
+    """
+    Refershs the datasources schema.
+    """
+
+    for ds in models.DataSource.all():
+        logger.info("Refreshing schema for: {}".format(ds.name))
+        ds.get_schema(refresh=True)
+
+
 @celery.task(bind=True, base=BaseTask, track_started=True)
 def execute_query(self, query, data_source_id):
     # TODO: maybe this should be a class?

--- a/redash/worker.py
+++ b/redash/worker.py
@@ -15,6 +15,10 @@ celery_schedule = {
     'cleanup_tasks': {
         'task': 'redash.tasks.cleanup_tasks',
         'schedule': timedelta(minutes=5)
+    },
+    'refresh_schemas': {
+        'task': 'redash.tasks.refresh_schemas',
+        'schedule': timedelta(minutes=30)
     }
 }
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -7,7 +7,9 @@ settings.DATABASE_CONFIG = {
     'threadlocals': True
 }
 
-from redash import models
+settings.REDIS_URL = "redis://localhost:6379/5"
+
+from redash import models, redis_connection
 
 logging.getLogger('peewee').setLevel(logging.INFO)
 
@@ -20,6 +22,7 @@ class BaseTestCase(TestCase):
     def tearDown(self):
         models.db.close_db(None)
         models.create_db(False, True)
+        redis_connection.flushdb()
 
     def assertResponseEqual(self, expected, actual):
         for k, v in expected.iteritems():

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,13 +1,15 @@
+import os
+os.environ['REDASH_REDIS_URL'] = "redis://localhost:6379/5"
+
 import logging
 from unittest import TestCase
 import datetime
 from redash import settings
+
 settings.DATABASE_CONFIG = {
     'name': 'circle_test',
     'threadlocals': True
 }
-
-settings.REDIS_URL = "redis://localhost:6379/5"
 
 from redash import models, redis_connection
 

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -47,7 +47,7 @@ user_factory = ModelFactory(redash.models.User,
 data_source_factory = ModelFactory(redash.models.DataSource,
                                    name='Test',
                                    type='pg',
-                                   options='')
+                                   options='{"dbname": "test"}')
 
 
 dashboard_factory = ModelFactory(redash.models.Dashboard,

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -2,10 +2,12 @@
 import datetime
 import json
 from unittest import TestCase
+import mock
 from tests import BaseTestCase
 from redash import models
 from factories import dashboard_factory, query_factory, data_source_factory, query_result_factory, user_factory, widget_factory
 from redash.utils import gen_query_hash
+from redash import query_runner
 
 
 class DashboardTest(BaseTestCase):
@@ -194,6 +196,43 @@ class QueryArchiveTest(BaseTestCase):
 
         self.assertEqual(None, query.schedule)
 
+
+class DataSourceTest(BaseTestCase):
+    def test_get_schema(self):
+        return_value = "{}"
+        with mock.patch('redash.query_runner.pg.PostgreSQL.get_schema') as patched_get_schema:
+            patched_get_schema.return_value = return_value
+
+            ds = data_source_factory.create()
+            schema = ds.get_schema()
+
+            self.assertEqual(return_value, schema)
+
+    def test_get_schema_uses_cache(self):
+        return_value = "{}"
+        with mock.patch('redash.query_runner.pg.PostgreSQL.get_schema') as patched_get_schema:
+            patched_get_schema.return_value = return_value
+
+            ds = data_source_factory.create()
+            ds.get_schema()
+            schema = ds.get_schema()
+
+            self.assertEqual(return_value, schema)
+            self.assertEqual(patched_get_schema.call_count, 1)
+
+    def test_get_schema_skips_cache_with_refresh_true(self):
+        return_value = "{}"
+        with mock.patch('redash.query_runner.pg.PostgreSQL.get_schema') as patched_get_schema:
+            patched_get_schema.return_value = return_value
+
+            ds = data_source_factory.create()
+            ds.get_schema()
+            new_return_value = '{"new":true}'
+            patched_get_schema.return_value = new_return_value
+            schema = ds.get_schema(refresh=True)
+
+            self.assertEqual(new_return_value, schema)
+            self.assertEqual(patched_get_schema.call_count, 2)
 
 
 class QueryResultTest(BaseTestCase):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -199,7 +199,8 @@ class QueryArchiveTest(BaseTestCase):
 
 class DataSourceTest(BaseTestCase):
     def test_get_schema(self):
-        return_value = "{}"
+        return_value = [{'name': 'table', 'columns': []}]
+
         with mock.patch('redash.query_runner.pg.PostgreSQL.get_schema') as patched_get_schema:
             patched_get_schema.return_value = return_value
 
@@ -209,7 +210,7 @@ class DataSourceTest(BaseTestCase):
             self.assertEqual(return_value, schema)
 
     def test_get_schema_uses_cache(self):
-        return_value = "{}"
+        return_value = [{'name': 'table', 'columns': []}]
         with mock.patch('redash.query_runner.pg.PostgreSQL.get_schema') as patched_get_schema:
             patched_get_schema.return_value = return_value
 
@@ -221,13 +222,13 @@ class DataSourceTest(BaseTestCase):
             self.assertEqual(patched_get_schema.call_count, 1)
 
     def test_get_schema_skips_cache_with_refresh_true(self):
-        return_value = "{}"
+        return_value = [{'name': 'table', 'columns': []}]
         with mock.patch('redash.query_runner.pg.PostgreSQL.get_schema') as patched_get_schema:
             patched_get_schema.return_value = return_value
 
             ds = data_source_factory.create()
             ds.get_schema()
-            new_return_value = '{"new":true}'
+            new_return_value = [{'name': 'new_table', 'columns': []}]
             patched_get_schema.return_value = new_return_value
             schema = ds.get_schema(refresh=True)
 


### PR DESCRIPTION
* Added API endpoint to return the datasource schema. Currently only the PostgreSQL & MySQL datasources supports it.
* Upgraded CodeMirror version and added the `anyword-hint` plugin (does autocomplete based on words in the existing text or naive autocomplete of "words" in the schema).
* Ugly schema browser alongside the query.

 (Closes: #15, Closes #308)