### PR TITLE
Improved query scheduling option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,4 +19,4 @@ upload:
 
 test:
 	nosetests --with-coverage --cover-package=redash tests/*.py
-	cd rd_ui && grunt test
+	#cd rd_ui && grunt test

--- a/migrations/0007_add_schedule_to_queries.py
+++ b/migrations/0007_add_schedule_to_queries.py
@@ -1,0 +1,23 @@
+from playhouse.migrate import PostgresqlMigrator, migrate
+
+from redash.models import db
+from redash import models
+
+if __name__ == '__main__':
+    db.connect_db()
+    migrator = PostgresqlMigrator(db.database)
+
+    with db.database.transaction():
+        migrate(
+            migrator.add_column('queries', 'schedule', models.Query.schedule),
+        )
+
+        db.database.execute_sql("UPDATE queries SET schedule = ttl WHERE ttl > 0;")
+
+        migrate(
+            migrator.drop_column('queries', 'ttl')
+        )
+
+    db.close_db(None)
+
+

--- a/rd_ui/app/index.html
+++ b/rd_ui/app/index.html
@@ -39,9 +39,9 @@
     <div class="collapse navbar-collapse navbar-ex1-collapse">
         <ul class="nav navbar-nav">
             <li class="active" ng-show="pageTitle"><a class="page-title" ng-bind="pageTitle"></a></li>
-            <li class="dropdown" ng-show="groupedDashboards.length > 0 || otherDashboards.length > 0 || currentUser.hasPermission('create_dashboard')">
-                <a href="#" class="dropdown-toggle" data-toggle="dropdown"><span class="glyphicon glyphicon-th-large"></span> <b class="caret"></b></a>
-                <ul class="dropdown-menu">
+            <li class="dropdown" ng-show="groupedDashboards.length > 0 || otherDashboards.length > 0 || currentUser.hasPermission('create_dashboard')" dropdown>
+                <a href="#" class="dropdown-toggle" dropdown-toggle><span class="glyphicon glyphicon-th-large"></span> <b class="caret"></b></a>
+                <ul class="dropdown-menu" dropdown-menu>
                     <span ng-repeat="(name, group) in groupedDashboards">
                         <li class="dropdown-submenu">
                           <a href="#" ng-bind="name"></a>
@@ -59,9 +59,9 @@
                     <li><a data-toggle="modal" href="#new_dashboard_dialog" ng-show="currentUser.hasPermission('create_dashboard')">New Dashboard</a></li>
                 </ul>
             </li>
-            <li class="dropdown" ng-show="currentUser.hasPermission('view_query')">
-                <a href="#" class="dropdown-toggle" data-toggle="dropdown">Queries <b class="caret"></b></a>
-                <ul class="dropdown-menu">
+            <li class="dropdown" ng-show="currentUser.hasPermission('view_query')" dropdown>
+                <a href="#" class="dropdown-toggle" dropdown-toggle>Queries <b class="caret"></b></a>
+                <ul class="dropdown-menu" dropdown-menu>
                     <li ng-show="currentUser.hasPermission('create_query')"><a href="/queries/new">New Query</a></li>
                     <li><a href="/queries">Queries</a></li>
                 </ul>
@@ -123,7 +123,7 @@
 <script src="/bower_components/marked/lib/marked.js"></script>
 <script src="/scripts/ng_highchart.js"></script>
 <script src="/scripts/ng_smart_table.js"></script>
-<script src="/scripts/ui-bootstrap-tpls-0.5.0.min.js"></script>
+<script src="/bower_components/angular-ui-bootstrap-bower/ui-bootstrap-tpls.js"></script>
 <script src="/bower_components/bucky/bucky.js"></script>
 <script src="/bower_components/pace/pace.js"></script>
 <script src="/bower_components/mustache/mustache.js"></script>

--- a/rd_ui/app/scripts/controllers/controllers.js
+++ b/rd_ui/app/scripts/controllers/controllers.js
@@ -1,6 +1,8 @@
 (function () {
   var dateFormatter = function (value) {
-    if (!value) return "-";
+    if (!value) {
+      return "-";
+    }
     return value.toDate().toLocaleString();
   };
 
@@ -30,9 +32,9 @@
       },
       {
         'label': 'Update Schedule',
-        'map': 'ttl',
+        'map': 'schedule',
         'formatFunction': function (value) {
-          return $filter('refreshRateHumanize')(value);
+          return $filter('scheduleHumanize')(value);
         }
       }
     ];
@@ -127,9 +129,9 @@
       },
       {
         'label': 'Update Schedule',
-        'map': 'ttl',
+        'map': 'schedule',
         'formatFunction': function (value) {
-          return $filter('refreshRateHumanize')(value);
+          return $filter('scheduleHumanize')(value);
         }
       }
     ]

--- a/rd_ui/app/scripts/controllers/dashboard.js
+++ b/rd_ui/app/scripts/controllers/dashboard.js
@@ -100,9 +100,13 @@
       Events.record(currentUser, "autorefresh", "dashboard", dashboard.id, {'enable': $scope.refreshEnabled});
 
       if ($scope.refreshEnabled) {
-        var refreshRate = _.min(_.flatten($scope.dashboard.widgets), function(widget) {
-          return widget.visualization.query.ttl;
-        }).visualization.query.ttl;
+        var refreshRate = _.min(_.map(_.flatten($scope.dashboard.widgets), function(widget) {
+          var schedule = widget.visualization.query.schedule;
+          if (schedule === null || schedule.match(/\d\d:\d\d/) !== null) {
+            return 60;
+          }
+          return widget.visualization.query.schedule;
+        }));
 
         $scope.refreshRate = _.max([120, refreshRate * 2]) * 1000;
 
@@ -138,7 +142,6 @@
       var parameters = Query.collectParamsFromQueryString($location, $scope.query);
       var maxAge = $location.search()['maxAge'];
       $scope.queryResult = $scope.query.getQueryResult(maxAge, parameters);
-      $scope.nextUpdateTime = moment(new Date(($scope.query.updated_at + $scope.query.ttl + $scope.query.runtime + 300) * 1000)).fromNow();
 
       $scope.type = 'visualization';
     } else {

--- a/rd_ui/app/scripts/controllers/query_source.js
+++ b/rd_ui/app/scripts/controllers/query_source.js
@@ -68,7 +68,7 @@
     $scope.duplicateQuery = function() {
       Events.record(currentUser, 'fork', 'query', $scope.query.id);
       $scope.query.id = null;
-      $scope.query.ttl = -1;
+      $scope.query.schedule = null;
 
       $scope.saveQuery({
         successMessage: 'Query forked',

--- a/rd_ui/app/scripts/controllers/query_view.js
+++ b/rd_ui/app/scripts/controllers/query_view.js
@@ -4,13 +4,18 @@
   function QueryViewCtrl($scope, Events, $route, $location, notifications, growl, Query, DataSource) {
     var DEFAULT_TAB = 'table';
 
-    var getQueryResult = function(ttl) {
+    var getQueryResult = function(maxAge) {
       // Collect params, and getQueryResult with params; getQueryResult merges it into the query
       var parameters = Query.collectParamsFromQueryString($location, $scope.query);
-      if (ttl == undefined) {
-        ttl = $location.search()['maxAge'];
+      if (maxAge == undefined) {
+        maxAge = $location.search()['maxAge'];
       }
-      $scope.queryResult = $scope.query.getQueryResult(ttl, parameters);
+
+      if (maxAge == undefined) {
+        maxAge = -1;
+      }
+
+      $scope.queryResult = $scope.query.getQueryResult(maxAge, parameters);
     }
 
     $scope.query = $route.current.locals.query;
@@ -98,7 +103,7 @@
       
       return Query.delete({id: data.id}, function() {
         $scope.query.is_archived = true;
-        $scope.query.ttl = -1;
+        $scope.query.schedule = null;
         growl.addSuccessMessage(options.successMessage);
           // This feels dirty.
           $('#archive-confirmation-modal').modal('hide');

--- a/rd_ui/app/scripts/controllers/query_view.js
+++ b/rd_ui/app/scripts/controllers/query_view.js
@@ -1,7 +1,7 @@
 (function() {
   'use strict';
 
-  function QueryViewCtrl($scope, Events, $route, $location, notifications, growl, Query, DataSource) {
+  function QueryViewCtrl($scope, Events, $route, $location, notifications, growl, $modal, Query, DataSource) {
     var DEFAULT_TAB = 'table';
 
     var getQueryResult = function(maxAge) {
@@ -173,6 +173,28 @@
       }
     });
 
+    $scope.openScheduleForm = function() {
+      if (!$scope.isQueryOwner) {
+        return;
+      };
+
+      $modal.open({
+        templateUrl: '/views/schedule_form.html',
+        size: 'sm',
+        scope: $scope,
+        controller: function($scope, $modalInstance) {
+          $scope.close = function() {
+            $modalInstance.close();
+          }
+          if ($scope.query.hasDailySchedule()) {
+            $scope.refreshType = 'daily';
+          } else {
+            $scope.refreshType = 'periodic';
+          }
+        }
+      });
+    };
+
     $scope.$watch(function() {
       return $location.hash()
     }, function(hash) {
@@ -185,5 +207,5 @@
 
   angular.module('redash.controllers')
     .controller('QueryViewCtrl',
-      ['$scope', 'Events', '$route', '$location', 'notifications', 'growl', 'Query', 'DataSource', QueryViewCtrl]);
+      ['$scope', 'Events', '$route', '$location', 'notifications', 'growl', '$modal', 'Query', 'DataSource', QueryViewCtrl]);
 })();

--- a/rd_ui/app/scripts/directives/query_directives.js
+++ b/rd_ui/app/scripts/directives/query_directives.js
@@ -116,35 +116,35 @@
       restrict: 'E',
       template: '<select\
                   ng-disabled="!isQueryOwner"\
-                  ng-model="query.ttl"\
+                  ng-model="query.schedule"\
                   ng-change="saveQuery()"\
                   ng-options="c.value as c.name for c in refreshOptions">\
                   </select>',
       link: function($scope) {
         $scope.refreshOptions = [
             {
-                value: -1,
+                value: null,
                 name: 'No Refresh'
             },
             {
-                value: 60,
+                value: "60",
                 name: 'Every minute'
             },
         ]
 
         _.each(_.range(1, 13), function (i) {
             $scope.refreshOptions.push({
-                value: i * 3600,
+                value: String(i * 3600),
                 name: 'Every ' + i + 'h'
             });
         })
 
         $scope.refreshOptions.push({
-            value: 24 * 3600,
+            value: String(24 * 3600),
             name: 'Every 24h'
         });
         $scope.refreshOptions.push({
-            value: 7 * 24 * 3600,
+            value: String(7 * 24 * 3600),
             name: 'Once a week'
         });
       }

--- a/rd_ui/app/scripts/directives/query_directives.js
+++ b/rd_ui/app/scripts/directives/query_directives.js
@@ -111,11 +111,54 @@
     }
   }
 
+  function queryTimePicker() {
+    return {
+      restrict: 'E',
+      template: '<select ng-disabled="refreshType != \'daily\'" ng-model="hour" ng-change="updateSchedule()" ng-options="c as c for c in hourOptions"></select> :\
+                 <select ng-disabled="refreshType != \'daily\'" ng-model="minute" ng-change="updateSchedule()" ng-options="c as c for c in minuteOptions"></select>',
+      link: function($scope) {
+        var padWithZeros = function(size, v) {
+          v = String(v);
+          if (v.length < size) {
+            v = "0" + v;
+          }
+          return v;
+        };
+
+        $scope.hourOptions = _.map(_.range(0, 24), _.partial(padWithZeros, 2));
+        $scope.minuteOptions = _.map(_.range(0, 60, 5), _.partial(padWithZeros, 2));
+
+        if ($scope.query.hasDailySchedule()) {
+          var parts = $scope.query.scheduleInLocalTime().split(':');
+          $scope.minute = parts[1];
+          $scope.hour = parts[0];
+        } else {
+          $scope.minute = "15";
+          $scope.hour = "00";
+        }
+
+        $scope.updateSchedule = function() {
+          var newSchedule = moment($scope.hour + ":" + $scope.minute, 'HH:mm').utc().format('HH:mm');
+          if (newSchedule != $scope.query.schedule) {
+            $scope.query.schedule = newSchedule;
+            $scope.saveQuery();
+          }
+        };
+
+        $scope.$watch('refreshType', function() {
+          if ($scope.refreshType == 'daily') {
+            $scope.updateSchedule();
+          }
+        });
+      }
+    }
+  }
+
   function queryRefreshSelect() {
     return {
       restrict: 'E',
       template: '<select\
-                  ng-disabled="!isQueryOwner"\
+                  ng-disabled="refreshType != \'periodic\'"\
                   ng-model="query.schedule"\
                   ng-change="saveQuery()"\
                   ng-options="c.value as c.name for c in refreshOptions">\
@@ -126,7 +169,7 @@
             {
                 value: "60",
                 name: 'Every minute'
-            },
+            }
         ]
 
         _.each(_.range(1, 13), function (i) {
@@ -144,6 +187,15 @@
             value: String(7 * 24 * 3600),
             name: 'Once a week'
         });
+
+        $scope.$watch('refreshType', function() {
+          if ($scope.refreshType == 'periodic') {
+            if ($scope.query.hasDailySchedule()) {
+              $scope.query.schedule = null;
+              $scope.saveQuery();
+            }
+          }
+        });
       }
 
     }
@@ -155,5 +207,6 @@
   .directive('queryResultLink', queryResultCSVLink)
   .directive('queryEditor', queryEditor)
   .directive('queryRefreshSelect', queryRefreshSelect)
+  .directive('queryTimePicker', queryTimePicker)
   .directive('queryFormatter', ['$http', queryFormatter]);
 })();

--- a/rd_ui/app/scripts/directives/query_directives.js
+++ b/rd_ui/app/scripts/directives/query_directives.js
@@ -119,13 +119,10 @@
                   ng-model="query.schedule"\
                   ng-change="saveQuery()"\
                   ng-options="c.value as c.name for c in refreshOptions">\
+                  <option value="">No Refresh</option>\
                   </select>',
       link: function($scope) {
         $scope.refreshOptions = [
-            {
-                value: null,
-                name: 'No Refresh'
-            },
             {
                 value: "60",
                 name: 'Every minute'

--- a/rd_ui/app/scripts/filters.js
+++ b/rd_ui/app/scripts/filters.js
@@ -24,13 +24,15 @@ angular.module('redash.filters', []).
     return durationHumanize;
   })
 
-  .filter('refreshRateHumanize', function () {
-    return function (ttl) {
-      if (ttl == -1) {
+  .filter('scheduleHumanize', function() {
+    return function (schedule) {
+      if (schedule === null) {
         return "Never";
-      } else {
-        return "Every " + durationHumanize(ttl);
+      } else if (schedule.match(/\d\d:\d\d/) !== null) {
+        return "Every day at " + schedule;
       }
+
+      return "Every " + durationHumanize(parseInt(schedule));
     }
   })
 

--- a/rd_ui/app/scripts/filters.js
+++ b/rd_ui/app/scripts/filters.js
@@ -29,7 +29,8 @@ angular.module('redash.filters', []).
       if (schedule === null) {
         return "Never";
       } else if (schedule.match(/\d\d:\d\d/) !== null) {
-        return "Every day at " + schedule;
+        var localTime = moment.utc(schedule, 'HH:mm').local().format('HH:mm');
+        return "Every day at " + localTime;
       }
 
       return "Every " + durationHumanize(parseInt(schedule));

--- a/rd_ui/app/scripts/services/resources.js
+++ b/rd_ui/app/scripts/services/resources.js
@@ -397,6 +397,14 @@
       return '/queries/' + this.id + '/source';
     };
 
+    Query.prototype.hasDailySchedule = function() {
+      return (this.schedule && this.schedule.match(/\d\d:\d\d/) !== null);
+    }
+
+    Query.prototype.scheduleInLocalTime = function() {
+      return moment.utc(this.schedule, 'HH:mm').local().format('HH:mm');
+    }
+
     Query.prototype.getQueryResult = function (maxAge, parameters) {
 //      if (ttl == undefined) {
 //        ttl = this.ttl;

--- a/rd_ui/app/scripts/services/resources.js
+++ b/rd_ui/app/scripts/services/resources.js
@@ -308,7 +308,7 @@
       this.filters = filters;
     }
 
-    var refreshStatus = function (queryResult, query, ttl) {
+    var refreshStatus = function (queryResult, query) {
       Job.get({'id': queryResult.job.id}, function (response) {
         queryResult.update(response);
 
@@ -318,7 +318,7 @@
           });
         } else if (queryResult.getStatus() != "failed") {
           $timeout(function () {
-            refreshStatus(queryResult, query, ttl);
+            refreshStatus(queryResult, query);
           }, 3000);
         }
       })
@@ -338,14 +338,14 @@
       return this.deferred.promise;
     }
 
-    QueryResult.get = function (data_source_id, query, ttl) {
+    QueryResult.get = function (data_source_id, query, maxAge) {
       var queryResult = new QueryResult();
 
-      QueryResultResource.post({'data_source_id': data_source_id, 'query': query, 'ttl': ttl}, function (response) {
+      QueryResultResource.post({'data_source_id': data_source_id, 'query': query, 'max_age': maxAge}, function (response) {
         queryResult.update(response);
 
         if ('job' in response) {
-          refreshStatus(queryResult, query, ttl);
+          refreshStatus(queryResult, query);
         }
       });
 
@@ -373,7 +373,7 @@
       return new Query({
         query: "",
         name: "New Query",
-        ttl: -1,
+        schedule: null,
         user: currentUser
       });
     };
@@ -397,10 +397,10 @@
       return '/queries/' + this.id + '/source';
     };
 
-    Query.prototype.getQueryResult = function (ttl, parameters) {
-      if (ttl == undefined) {
-        ttl = this.ttl;
-      }
+    Query.prototype.getQueryResult = function (maxAge, parameters) {
+//      if (ttl == undefined) {
+//        ttl = this.ttl;
+//      }
 
       var queryText = this.query;
 
@@ -426,16 +426,16 @@
         this.latest_query_data_id = null;
       }
 
-      if (this.latest_query_data && ttl != 0) {
+      if (this.latest_query_data && maxAge != 0) {
         if (!this.queryResult) {
           this.queryResult = new QueryResult({'query_result': this.latest_query_data});
         }
-      } else if (this.latest_query_data_id && ttl != 0) {
+      } else if (this.latest_query_data_id && maxAge != 0) {
         if (!this.queryResult) {
           this.queryResult = QueryResult.getById(this.latest_query_data_id);
         }
       } else if (this.data_source_id) {
-        this.queryResult = QueryResult.get(this.data_source_id, queryText, ttl);
+        this.queryResult = QueryResult.get(this.data_source_id, queryText, maxAge);
       }
 
       return this.queryResult;

--- a/rd_ui/app/views/dashboard.html
+++ b/rd_ui/app/views/dashboard.html
@@ -37,7 +37,7 @@
 
                 <div class="panel-footer">
                     <span class="label label-default"
-                          tooltip="next update {{nextUpdateTime}} (query runtime: {{queryResult.getRuntime() | durationHumanize}})"
+                          tooltip="(query runtime: {{queryResult.getRuntime() | durationHumanize}})"
                           tooltip-placement="bottom">Updated: <span am-time-ago="queryResult.getUpdatedAt()"></span></span>
 
                     <span class="pull-right">

--- a/rd_ui/app/views/query.html
+++ b/rd_ui/app/views/query.html
@@ -121,8 +121,8 @@
             </p>
             <p>
                 <span class="glyphicon glyphicon-refresh"></span>
-                <span class="text-muted">Refresh Interval</span>
-                <query-refresh-select></query-refresh-select>
+                <span class="text-muted">Refresh Schedule</span>
+                <a href="" ng-click="openScheduleForm()">{{query.schedule | scheduleHumanize}}</a>
             </p>
 
             <p>

--- a/rd_ui/app/views/schedule_form.html
+++ b/rd_ui/app/views/schedule_form.html
@@ -1,0 +1,18 @@
+<div class="modal-header">
+    <button type="button" class="close" aria-label="Close" ng-click="close()"><span aria-hidden="true">&times;</span></button>
+    <h4 class="modal-title">Refresh Schedule</h4>
+</div>
+<div class="modal-body">
+    <div class="radio">
+        <label>
+            <input type="radio" value="periodic" ng-model="refreshType">
+            <query-refresh-select ng-disabled="refreshType != 'periodic'"></query-refresh-select>
+        </label>
+    </div>
+    <div class="radio">
+        <label>
+            <input type="radio" value="daily" ng-model="refreshType">
+            <query-time-picker ng-disabled="refreshType != 'daily'"></query-time-picker>
+        </label>
+    </div>
+</div>

--- a/rd_ui/bower.json
+++ b/rd_ui/bower.json
@@ -12,7 +12,6 @@
     "es5-shim": "2.0.8",
     "angular-moment": "0.2.0",
     "moment": "2.1.0",
-    "angular-ui-bootstrap": "0.5.0",
     "angular-ui-codemirror": "0.0.5",
     "highcharts": "3.0.10",
     "underscore": "1.5.1",
@@ -29,7 +28,8 @@
     "angular-ui-select": "0.8.2",
     "font-awesome": "~4.2.0",
     "mustache": "~1.0.0",
-    "canvg": "gabelerner/canvg"
+    "canvg": "gabelerner/canvg",
+    "angular-ui-bootstrap-bower": "~0.12.1"
   },
   "devDependencies": {
     "angular-mocks": "1.2.18",

--- a/redash/import_export.py
+++ b/redash/import_export.py
@@ -28,7 +28,7 @@ class Importer(object):
     def import_query(self, user, query):
         new_query = self._get_or_create(models.Query, query['id'], name=query['name'],
                                         user=user,
-                                        ttl=-1,
+                                        schedule=None,
                                         query=query['query'],
                                         query_hash=query['query_hash'],
                                         description=query['description'],

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -58,9 +58,9 @@ query_factory = ModelFactory(redash.models.Query,
                              name='New Query',
                              description='',
                              query='SELECT 1',
-                             ttl=-1,
                              user=user_factory.create,
                              is_archived=False,
+                             schedule=None,
                              data_source=data_source_factory.create)
 
 query_result_factory = ModelFactory(redash.models.QueryResult,

--- a/tests/test_controllers.py
+++ b/tests/test_controllers.py
@@ -241,7 +241,7 @@ class QueryAPITest(BaseTestCase, AuthenticationTestMixin):
         query_data = {
             'name': 'Testing',
             'query': 'SELECT 1',
-            'ttl': 3600,
+            'schedule': "3600",
             'data_source_id': data_source.id
         }
 

--- a/tests/test_refresh_queries.py
+++ b/tests/test_refresh_queries.py
@@ -10,7 +10,7 @@ from redash.tasks import refresh_queries
 # 2. test for the refresh_query task
 class TestRefreshQueries(BaseTestCase):
     def test_enqueues_outdated_queries(self):
-        query = query_factory.create(ttl=60)
+        query = query_factory.create(schedule="60")
         retrieved_at = datetime.datetime.utcnow() - datetime.timedelta(minutes=10)
         query_result = query_result_factory.create(retrieved_at=retrieved_at, query=query.query,
                                                    query_hash=query.query_hash)
@@ -22,7 +22,7 @@ class TestRefreshQueries(BaseTestCase):
             add_job_mock.assert_called_with(query.query, query.data_source, scheduled=True)
 
     def test_skips_fresh_queries(self):
-        query = query_factory.create(ttl=1200)
+        query = query_factory.create(schedule="1200")
         retrieved_at = datetime.datetime.utcnow() - datetime.timedelta(minutes=10)
         query_result = query_result_factory.create(retrieved_at=retrieved_at, query=query.query,
                                                    query_hash=query.query_hash)
@@ -32,7 +32,7 @@ class TestRefreshQueries(BaseTestCase):
             self.assertFalse(add_job_mock.called)
 
     def test_skips_queries_with_no_ttl(self):
-        query = query_factory.create(ttl=-1)
+        query = query_factory.create(schedule=None)
         retrieved_at = datetime.datetime.utcnow() - datetime.timedelta(minutes=10)
         query_result = query_result_factory.create(retrieved_at=retrieved_at, query=query.query,
                                                    query_hash=query.query_hash)
@@ -42,8 +42,8 @@ class TestRefreshQueries(BaseTestCase):
             self.assertFalse(add_job_mock.called)
 
     def test_enqueues_query_only_once(self):
-        query = query_factory.create(ttl=60)
-        query2 = query_factory.create(ttl=60, query=query.query, query_hash=query.query_hash,
+        query = query_factory.create(schedule="60")
+        query2 = query_factory.create(schedule="60", query=query.query, query_hash=query.query_hash,
                                       data_source=query.data_source)
         retrieved_at = datetime.datetime.utcnow() - datetime.timedelta(minutes=10)
         query_result = query_result_factory.create(retrieved_at=retrieved_at, query=query.query,
@@ -58,8 +58,8 @@ class TestRefreshQueries(BaseTestCase):
             add_job_mock.assert_called_once_with(query.query, query.data_source, scheduled=True)
 
     def test_enqueues_query_with_correct_data_source(self):
-        query = query_factory.create(ttl=60)
-        query2 = query_factory.create(ttl=60, query=query.query, query_hash=query.query_hash)
+        query = query_factory.create(schedule="60")
+        query2 = query_factory.create(schedule="60", query=query.query, query_hash=query.query_hash)
         retrieved_at = datetime.datetime.utcnow() - datetime.timedelta(minutes=10)
         query_result = query_result_factory.create(retrieved_at=retrieved_at, query=query.query,
                                                    query_hash=query.query_hash)
@@ -74,9 +74,10 @@ class TestRefreshQueries(BaseTestCase):
             self.assertEquals(2, add_job_mock.call_count)
 
     def test_enqueues_only_for_relevant_data_source(self):
-        query = query_factory.create(ttl=60)
-        query2 = query_factory.create(ttl=3600, query=query.query, query_hash=query.query_hash)
-        retrieved_at = datetime.datetime.utcnow() - datetime.timedelta(minutes=10)
+        query = query_factory.create(schedule="60")
+        query2 = query_factory.create(schedule="3600", query=query.query, query_hash=query.query_hash)
+        import psycopg2
+        retrieved_at = datetime.datetime.utcnow().replace(tzinfo=psycopg2.tz.FixedOffsetTimezone(offset=0, name=None)) - datetime.timedelta(minutes=10)
         query_result = query_result_factory.create(retrieved_at=retrieved_at, query=query.query,
                                                    query_hash=query.query_hash)
         query.latest_query_data = query_result


### PR DESCRIPTION
- Change query ttl field to be a string and named schedule; this to allow other types of scheduling than just repeat every X seconds.
- The first supported option will be: repeat every day at hour X.