### PR TITLE
Allow undefined max_age parameter in query_results endpoint

### DIFF
--- a/redash/controllers.py
+++ b/redash/controllers.py
@@ -450,7 +450,7 @@ api.add_resource(VisualizationAPI, '/api/visualizations/<visualization_id>', end
 class QueryResultListAPI(BaseResource):
     @require_permission('execute_query')
     def post(self):
-        params = request.json
+        params = request.get_json(force=True)
 
         if settings.FEATURE_TABLES_PERMISSIONS:
             metadata = utils.SQLMetaData(params['query'])
@@ -476,7 +476,7 @@ class QueryResultListAPI(BaseResource):
             activity=params['query']
         ).save()
 
-        max_age = int(params['max_age'])
+        max_age = int(params.get('max_age', -1))
 
         if max_age == 0:
             query_result = None

--- a/tests/test_controllers.py
+++ b/tests/test_controllers.py
@@ -319,6 +319,17 @@ class QueryResultAPITest(BaseTestCase, AuthenticationTestMixin):
         self.paths = []
         super(QueryResultAPITest, self).setUp()
 
+    def test_post_result_list(self):
+        data_source = data_source_factory.create()
+        query_result = query_result_factory.create()
+        query = query_factory.create()
+
+        with app.test_client() as c, authenticated_user(c):
+            rv = json_request(c.post, '/api/query_results',
+                              data={'data_source_id': data_source.id,
+                                    'query': query.query})
+            self.assertEquals(rv.status_code, 200)
+
 
 class JobAPITest(BaseTestCase, AuthenticationTestMixin):
     def setUp(self):


### PR DESCRIPTION
An Error 500 would be returned by the endpoint if you attempt to
pass a query parameter to the dashboard since `maxAge` is undefined in the JavaScript code. This line of code was being executed:

https://github.com/EverythingMe/redash/blob/74a5121be232a0a6002928c38c7290298370c7e0/rd_ui/app/scripts/services/resources.js#L454