### PR TITLE
supervisord default config: separate queue for ad-hoc and scheduled queries 

### DIFF
--- a/redash/models.py
+++ b/redash/models.py
@@ -229,7 +229,7 @@ class DataSource(BaseModel):
     type = peewee.CharField()
     options = peewee.TextField()
     queue_name = peewee.CharField(default="queries")
-    scheduled_queue_name = peewee.CharField(default="queries")
+    scheduled_queue_name = peewee.CharField(default="scheduled_queries")
     created_at = DateTimeTZField(default=datetime.datetime.now)
 
     class Meta:

--- a/setup/files/supervisord.conf
+++ b/setup/files/supervisord.conf
@@ -20,9 +20,12 @@ autorestart=true
 stdout_logfile=/opt/redash/logs/api.log
 stderr_logfile=/opt/redash/logs/api_error.log
 
+# There are two queue types here: one for ad-hoc queries, and one for the refresh of scheduled queries
+# (note that "scheduled_queries" appears only in the queue list of "redash_celery_scheduled").
+# The default concurrency level for each is 2 (-c2), you can increase based on your machine's resources.
+
 [program:redash_celery]
-# separate queue for ad-hoc queries (note the queue list doesn't include "scheduled_queries")
-command=/opt/redash/current/bin/run celery worker --app=redash.worker --beat -c4 -Qqueries,celery
+command=/opt/redash/current/bin/run celery worker --app=redash.worker --beat -c2 -Qqueries,celery
 process_name=redash_celery
 numprocs=1
 priority=999
@@ -32,8 +35,7 @@ stdout_logfile=/opt/redash/logs/celery.log
 stderr_logfile=/opt/redash/logs/celery_error.log
  
 [program:redash_celery_scheduled]
-# separate queue for scheduled queries (note the queue list includes only "scheduled_queries")
-command=/opt/redash/current/bin/run celery worker --app=redash.worker -c4 -Qscheduled_queries
+command=/opt/redash/current/bin/run celery worker --app=redash.worker -c2 -Qscheduled_queries
 process_name=redash_celery_scheduled
 numprocs=1
 priority=999

--- a/setup/files/supervisord.conf
+++ b/setup/files/supervisord.conf
@@ -21,8 +21,20 @@ stdout_logfile=/opt/redash/logs/api.log
 stderr_logfile=/opt/redash/logs/api_error.log
 
 [program:redash_celery]
-command=/opt/redash/current/bin/run celery worker --app=redash.worker --beat -Qqueries,celery,scheduled_queries
+# separate queue for ad-hoc queries (note the queue list doesn't include "scheduled_queries")
+command=/opt/redash/current/bin/run celery worker --app=redash.worker --beat -c4 -Qqueries,celery
 process_name=redash_celery
+numprocs=1
+priority=999
+autostart=true
+autorestart=true
+stdout_logfile=/opt/redash/logs/celery.log
+stderr_logfile=/opt/redash/logs/celery_error.log
+ 
+[program:redash_celery_scheduled]
+# separate queue for scheduled queries (note the queue list includes only "scheduled_queries")
+command=/opt/redash/current/bin/run celery worker --app=redash.worker -c4 -Qscheduled_queries
+process_name=redash_celery_scheduled
 numprocs=1
 priority=999
 autostart=true


### PR DESCRIPTION
separated the queue for ad-hoc and for scheduled queries (someone who runs an ad-hoc query should not wait because there scheduled queries are being refreshed at that time)