### PR TITLE
Fix SSL Setup document which does not work correctly

### DIFF
--- a/_posts/2015-02-09-ssl.md
+++ b/_posts/2015-02-09-ssl.md
@@ -1,4 +1,4 @@
---- 
+---
 title: SSL (HTTPS) Setup
 layout: post
 category: deployment
@@ -15,22 +15,10 @@ If you used the provided images or the bootstrap script, to start using SSL with
 upstream redash_servers {
   server 127.0.0.1:5000;
 }
- 
+
 server {
-  listen   [::]:80;
-  listen   443  default_server  ssl;
-  
-  # Make sure to set paths to your certificate .pem and .key files.
-  ssl on;
-  ssl_certificate /path-to/cert.pem; # or crt
-  ssl_certificate_key /path-to/cert.key;
- 
-  access_log /var/log/nginx/redash.access.log;
- 
-  gzip on;
-  gzip_types *;
-  gzip_proxied any;
- 
+  listen 80;
+
   # Allow accessing /ping without https. Useful when placing behind load balancer.
   location /ping {
     proxy_set_header Host $http_host;
@@ -38,16 +26,34 @@ server {
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_pass       http://redash_servers;
   }
- 
+
   location / {
     # Enforce SSL.
-    if ($ssl_protocol = "") {
-      rewrite ^   https://$server_name$request_uri? permanent;
-    }
+    return 301 https://$host$request_uri;
+  }
+}
+
+server {
+  listen 443 ssl;
+
+  # Make sure to set paths to your certificate .pem and .key files.
+  ssl on;
+  ssl_certificate /path-to/cert.pem; # or crt
+  ssl_certificate_key /path-to/cert.key;
+
+  access_log /var/log/nginx/redash.access.log;
+
+  gzip on;
+  gzip_types *;
+  gzip_proxied any;
+
+  location / {
     proxy_set_header Host $http_host;
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
     proxy_pass       http://redash_servers;
+    proxy_redirect   off;
   }
 }
 ```


### PR DESCRIPTION
Current sample nginx config on http://redash.io/deployment/ssl.html does not work correctly.

- When I access to `https://redash_server/`, it redirect to `http://redash_server/login`. Because `X-Forwarded-Proto` header is not set correctly.
- I think it's easy to understand that dividing `server` settings for `http` and `https` and avoid to use `if` statement (see: http://wiki.nginx.org/IfIsEvil)