### PR TITLE
leaflet visualization: marker path bug handled

### DIFF
--- a/rd_ui/app/scripts/visualizations/map.js
+++ b/rd_ui/app/scripts/visualizations/map.js
@@ -111,7 +111,9 @@
               }).join('');
             };
 
-
+            // Following line is used to avoid "Couldn't autodetect L.Icon.Default.imagePath" error
+            // https://github.com/Leaflet/Leaflet/issues/766#issuecomment-7741039
+            L.Icon.Default.imagePath = L.Icon.Default.imagePath || "http://api.tiles.mapbox.com/mapbox.js/v2.2.1/images";
 
             function getBounds(e) {
               $scope.visualization.options.bounds = $scope.map.getBounds();


### PR DESCRIPTION
This PR fixes the following bug: Leaflet can't detect the path to the marker img in the 'compiled' version of Redash. This a known issue in Leaflet: https://github.com/mapbox/mapbox.js/issues/339

![redash-leaflet-marker-bug](https://cloud.githubusercontent.com/assets/6061036/8463380/3ec49014-2010-11e5-89b1-f880cb0c6723.png)