### PR TITLE
map visualization: options fixed

### DIFF
--- a/rd_ui/app/scripts/visualizations/map.js
+++ b/rd_ui/app/scripts/visualizations/map.js
@@ -12,7 +12,9 @@
     var editTemplate = '<map-editor></map-editor>';
     var defaultOptions = {
       'height': 500,
-      'draw': 'Marker'
+      'draw': 'Marker',
+      'draw_options' : ['Marker','Color'],
+      'classify':'none'
     };
 
     VisualizationProvider.registerVisualization({
@@ -228,8 +230,7 @@
       restrict: 'E',
       templateUrl: '/views/visualizations/map_editor.html',
       link: function($scope, elm, attrs) {
-        $scope.visualization.options.draw_options = ['Marker','Color'];
-        $scope.visualization.options.classify_columns = $scope.queryResult.columnNames.concat('none');
+        $scope.classify_columns = $scope.queryResult.columnNames.concat('none');
       }
     }
   });

--- a/rd_ui/app/scripts/visualizations/map.js
+++ b/rd_ui/app/scripts/visualizations/map.js
@@ -13,7 +13,6 @@
     var defaultOptions = {
       'height': 500,
       'draw': 'Marker',
-      'draw_options' : ['Marker','Color'],
       'classify':'none'
     };
 
@@ -230,6 +229,7 @@
       restrict: 'E',
       templateUrl: '/views/visualizations/map_editor.html',
       link: function($scope, elm, attrs) {
+        $scope.draw_options = ['Marker','Color'];
         $scope.classify_columns = $scope.queryResult.columnNames.concat('none');
       }
     }

--- a/rd_ui/app/views/visualizations/map_editor.html
+++ b/rd_ui/app/views/visualizations/map_editor.html
@@ -9,7 +9,7 @@
     <div class="form-group">
         <label class="col-lg-2">Draw option</label>
         <div class="col-sm-4">
-            <select ng-options="opt for opt in visualization.options.draw_options" ng-model="visualization.options.draw" class="form-control"></select>
+            <select ng-options="opt for opt in draw_options" ng-model="visualization.options.draw" class="form-control"></select>
         </div>
     </div>
     <div class="form-group">

--- a/rd_ui/app/views/visualizations/map_editor.html
+++ b/rd_ui/app/views/visualizations/map_editor.html
@@ -29,7 +29,7 @@
         <div class="form-group">
             <label class="col-lg-2">Classify by column</label>
             <div class="col-sm-4">
-                <select ng-options="name for name in visualization.options.classify_columns" ng-model="visualization.options.classify" class="form-control"></select>
+                <select ng-options="name for name in classify_columns" ng-model="visualization.options.classify" class="form-control"></select>
             </div>
         </div>
 


### PR DESCRIPTION
@arikfr hi ;). There were some problems with the options (for example, classify categories weren't visible before saving). This PR fixes that.