### PR TITLE
Bump up version of site to 0.6.2

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,5 @@
 source: .
-version: 0.5.0
+version: 0.6.2
 highlighter: pygments
 baseurl: ''
 markdown: redcarpet


### PR DESCRIPTION
<img width="401" alt="2015-07-04 22 30 51" src="https://cloud.githubusercontent.com/assets/346598/8508084/da9d099c-229c-11e5-89b5-b62cbe3b412a.png">

Current version is `0.6.2` but official site says it is `0.5.0`.

In addition, I think it is necessary include in page title,because user always want latest version document.
If you want remain `version` string, it should update at every release.