### PR TITLE
Feature: Support InfluxDB v0.9+

### DIFF
--- a/redash/query_runner/influx_db.py
+++ b/redash/query_runner/influx_db.py
@@ -1,0 +1,83 @@
+import json
+import logging
+
+from redash.utils import JSONEncoder
+from redash.query_runner import *
+
+logger = logging.getLogger(__name__)
+
+try:
+    from influxdb import InfluxDBClusterClient
+    enabled = True
+
+except ImportError:
+    logger.warning("Missing dependencies. Please install influxdb.")
+    logger.warning("You can use pip:   pip install influxdb")
+    enabled = False
+
+def _transform_result(results):
+    result_columns = []
+    result_rows = []
+
+    for result in results:
+        if not result_columns:
+            for c in result.raw['series'][0]['columns']:
+                result_columns.append({ "name": c })
+
+        for point in result.get_points():
+            result_rows.append(point)
+
+    return json.dumps({
+        "columns" : result_columns,
+        "rows" : result_rows
+    }, cls=JSONEncoder)
+
+class InfluxDB(BaseQueryRunner):
+    @classmethod
+    def configuration_schema(cls):
+        return {
+            'type': 'object',
+            'properties': {
+                'url': {
+                    'type': 'string'
+                }
+            },
+            'required': ['url']
+        }
+
+    @classmethod
+    def enabled(cls):
+        return enabled
+
+    @classmethod
+    def annotate_query(cls):
+        return False
+
+    @classmethod
+    def type(cls):
+        return "influxdb"
+
+    def __init__(self, configuration_json):
+        super(InfluxDB, self).__init__(configuration_json)
+
+    def run_query(self, query):
+        client = InfluxDBClusterClient.from_DSN(self.configuration['url'])
+
+        logger.debug("influxdb url: %s", self.configuration['url'])
+        logger.debug("influxdb got query: %s", query)
+
+        try:
+            results = client.query(query)
+            if not isinstance(results, list):
+                results = [results]
+
+            json_data = _transform_result(results)
+            error = None
+        except Exception, ex:
+            json_data = None
+            error = ex.message
+
+        return json_data, error
+
+
+register(InfluxDB)

--- a/redash/settings.py
+++ b/redash/settings.py
@@ -86,6 +86,7 @@ QUERY_RUNNERS = array_from_string(os.environ.get("REDASH_ENABLED_QUERY_RUNNERS",
     'redash.query_runner.pg',
     'redash.query_runner.script',
     'redash.query_runner.url',
+    'redash.query_runner.influx_db',
 ])))
 
 # Features:


### PR DESCRIPTION
This pull request experimental support for [InfluxDB](https://influxdb.com/) but only v0.9+. Because InfluxDB has no backward compatibility for older than 0.8.

## Config

- Type: influxdb
- Options:
  - Url (url) (mandatory)

## Add Data Source command

```
bin/run ./manage.py ds new -n example -t influxdb -o '{"url":"influxdb://root:root@localhost:8086/example"}'
```
