### PR TITLE
Feature: support for per user API keys

### DIFF
--- a/migrations/0009_add_api_key_to_user.py
+++ b/migrations/0009_add_api_key_to_user.py
@@ -1,0 +1,27 @@
+from playhouse.migrate import PostgresqlMigrator, migrate
+
+from redash.models import db
+from redash import models
+
+if __name__ == '__main__':
+    db.connect_db()
+    migrator = PostgresqlMigrator(db.database)
+
+    with db.database.transaction():
+        column = models.User.api_key
+        column.null = True
+        migrate(
+            migrator.add_column('users', 'api_key', models.User.api_key),
+        )
+
+        for user in models.User.select():
+            user.save()
+
+        migrate(
+            migrator.add_not_null('users', 'api_key')
+        )
+
+    db.close_db(None)
+
+
+

--- a/redash/models.py
+++ b/redash/models.py
@@ -153,7 +153,7 @@ class User(ModelTimestampsMixin, BaseModel, UserMixin, PermissionsCheckMixin):
     email = peewee.CharField(max_length=320, index=True, unique=True)
     password_hash = peewee.CharField(max_length=128, null=True)
     groups = ArrayField(peewee.CharField, default=DEFAULT_GROUPS)
-    api_key = peewee.CharField(max_length=40)
+    api_key = peewee.CharField(max_length=40, unique=True)
 
     class Meta:
         db_table = 'users'

--- a/redash/models.py
+++ b/redash/models.py
@@ -15,6 +15,7 @@ import psycopg2
 
 from redash import utils, settings, redis_connection
 from redash.query_runner import get_query_runner
+from utils import generate_token
 
 
 class Database(object):
@@ -152,6 +153,7 @@ class User(ModelTimestampsMixin, BaseModel, UserMixin, PermissionsCheckMixin):
     email = peewee.CharField(max_length=320, index=True, unique=True)
     password_hash = peewee.CharField(max_length=128, null=True)
     groups = ArrayField(peewee.CharField, default=DEFAULT_GROUPS)
+    api_key = peewee.CharField(max_length=40)
 
     class Meta:
         db_table = 'users'
@@ -168,6 +170,12 @@ class User(ModelTimestampsMixin, BaseModel, UserMixin, PermissionsCheckMixin):
     def __init__(self, *args, **kwargs):
         super(User, self).__init__(*args, **kwargs)
         self._allowed_tables = None
+
+    def pre_save(self, created):
+        super(User, self).pre_save(created)
+
+        if not self.api_key:
+            self.api_key = generate_token(40)
 
     @property
     def permissions(self):
@@ -187,6 +195,10 @@ class User(ModelTimestampsMixin, BaseModel, UserMixin, PermissionsCheckMixin):
     @classmethod
     def get_by_email(cls, email):
         return cls.get(cls.email == email)
+
+    @classmethod
+    def get_by_api_key(cls, api_key):
+        return cls.get(cls.api_key == api_key)
 
     def __unicode__(self):
         return '%r, %r' % (self.name, self.email)

--- a/redash/utils.py
+++ b/redash/utils.py
@@ -4,6 +4,7 @@ import codecs
 import decimal
 import datetime
 import json
+import random
 import re
 import hashlib
 import sqlparse
@@ -87,6 +88,14 @@ def gen_query_hash(sql):
     sql = "".join(sql.split()).lower()
     return hashlib.md5(sql.encode('utf-8')).hexdigest()
 
+
+def generate_token(length):
+    chars = ('abcdefghijklmnopqrstuvwxyz'
+             'ABCDEFGHIJKLMNOPQRSTUVWXYZ'
+             '0123456789')
+
+    rand = random.SystemRandom()
+    return ''.join(rand.choice(chars) for x in range(length))
 
 class JSONEncoder(json.JSONEncoder):
     """Custom JSON encoding class, to handle Decimal and datetime.date instances.

--- a/redash/wsgi.py
+++ b/redash/wsgi.py
@@ -1,5 +1,6 @@
 import json
 from flask import Flask, make_response
+from werkzeug.wrappers import Response
 from flask.ext.restful import Api
 
 from redash import settings, utils
@@ -24,10 +25,13 @@ app.config['DATABASE'] = settings.DATABASE_CONFIG
 db.init_app(app)
 
 from redash.authentication import setup_authentication
-auth = setup_authentication(app)
+setup_authentication(app)
 
 @api.representation('application/json')
 def json_representation(data, code, headers=None):
+    # Flask-Restful checks only for flask.Response but flask-login uses werkzeug.wrappers.Response
+    if isinstance(data, Response):
+        return data
     resp = make_response(json.dumps(data, cls=utils.JSONEncoder), code)
     resp.headers.extend(headers or {})
     return resp

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 Flask==0.10.1
 Flask-Admin==1.1.0
 Flask-RESTful==0.2.10
-Flask-Login==0.2.9
+Flask-Login==0.2.11
 Flask-OAuth==0.12
 passlib==1.6.2
 Jinja2==2.7.2

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -1,9 +1,10 @@
-from flask.ext.login import current_user
+from flask import request
 from mock import patch
+import time
 from tests import BaseTestCase
 from redash import models
 from redash.google_oauth import create_and_login_user
-from redash.authentication import ApiKeyAuthentication
+from redash.authentication import api_key_load_user_from_request, hmac_load_user_from_request, sign
 from tests.factories import user_factory, query_factory
 from redash.wsgi import app
 
@@ -18,29 +19,72 @@ class TestApiKeyAuthentication(BaseTestCase):
         self.query = query_factory.create(api_key=self.api_key)
 
     def test_no_api_key(self):
-        auth = ApiKeyAuthentication()
         with app.test_client() as c:
             rv = c.get('/api/queries/{0}'.format(self.query.id))
-            self.assertFalse(auth.verify_authentication())
+            self.assertIsNone(api_key_load_user_from_request(request))
 
     def test_wrong_api_key(self):
-        auth = ApiKeyAuthentication()
         with app.test_client() as c:
             rv = c.get('/api/queries/{0}'.format(self.query.id), query_string={'api_key': 'whatever'})
-            self.assertFalse(auth.verify_authentication())
+            self.assertIsNone(api_key_load_user_from_request(request))
 
     def test_correct_api_key(self):
-        auth = ApiKeyAuthentication()
         with app.test_client() as c:
             rv = c.get('/api/queries/{0}'.format(self.query.id), query_string={'api_key': self.api_key})
-            self.assertTrue(auth.verify_authentication())
+            self.assertIsNotNone(api_key_load_user_from_request(request))
 
     def test_no_query_id(self):
-        auth = ApiKeyAuthentication()
         with app.test_client() as c:
             rv = c.get('/api/queries', query_string={'api_key': self.api_key})
-            self.assertFalse(auth.verify_authentication())
+            self.assertIsNone(api_key_load_user_from_request(request))
 
+    def test_user_api_key(self):
+        user = user_factory.create(api_key="user_key")
+        with app.test_client() as c:
+            rv = c.get('/api/queries/', query_string={'api_key': user.api_key})
+            self.assertEqual(user.id, api_key_load_user_from_request(request).id)
+
+class TestHMACAuthentication(BaseTestCase):
+    #
+    # This is a bad way to write these tests, but the way Flask works doesn't make it easy to write them properly...
+    #
+    def setUp(self):
+        super(TestHMACAuthentication, self).setUp()
+        self.api_key = 10
+        self.query = query_factory.create(api_key=self.api_key)
+        self.path = '/api/queries/{0}'.format(self.query.id)
+        self.expires = time.time() + 1800
+
+    def signature(self, expires):
+        return sign(self.query.api_key, self.path, expires)
+
+    def test_no_signature(self):
+        with app.test_client() as c:
+            rv = c.get(self.path)
+            self.assertIsNone(hmac_load_user_from_request(request))
+
+    def test_wrong_signature(self):
+        with app.test_client() as c:
+            rv = c.get(self.path, query_string={'signature': 'whatever', 'expires': self.expires})
+            self.assertIsNone(hmac_load_user_from_request(request))
+
+    def test_correct_signature(self):
+        with app.test_client() as c:
+            rv = c.get('/api/queries/{0}'.format(self.query.id), query_string={'signature': self.signature(self.expires), 'expires': self.expires})
+            self.assertIsNotNone(hmac_load_user_from_request(request))
+
+    def test_no_query_id(self):
+        with app.test_client() as c:
+            rv = c.get('/api/queries', query_string={'api_key': self.api_key})
+            self.assertIsNone(hmac_load_user_from_request(request))
+
+    def test_user_api_key(self):
+        user = user_factory.create(api_key="user_key")
+        path = '/api/queries/'
+        with app.test_client() as c:
+            signature = sign(user.api_key, path, self.expires)
+            rv = c.get(path, query_string={'signature': signature, 'expires': self.expires, 'user_id': user.id})
+            self.assertEqual(user.id, hmac_load_user_from_request(request).id)
 
 class TestCreateAndLoginUser(BaseTestCase):
     def test_logins_valid_user(self):


### PR DESCRIPTION
Until now, only queries had API keys and you could access either a query or query results objects without using Google OAuth or username/password Authentication. Now we add API keys for users as well, so you can access any API method using the key.

(closes #13)