### PR TITLE
Add timeout setting for BigQuery query runner

### DIFF
--- a/redash/query_runner/big_query.py
+++ b/redash/query_runner/big_query.py
@@ -8,6 +8,7 @@ import time
 
 import requests
 
+from redash import settings
 from redash.query_runner import *
 from redash.utils import JSONEncoder
 
@@ -113,7 +114,7 @@ class BigQuery(BaseQueryRunner):
         key = json.loads(b64decode(self.configuration['jsonKeyFile']))
 
         credentials = SignedJwtAssertionCredentials(key['client_email'], key['private_key'], scope=scope)
-        http = httplib2.Http()
+        http = httplib2.Http(timeout=settings.BIGQUERY_HTTP_TIMEOUT)
         http = credentials.authorize(http)
 
         return build("bigquery", "v2", http=http)

--- a/redash/settings.py
+++ b/redash/settings.py
@@ -139,3 +139,6 @@ CLIENT_SIDE_METRICS = parse_boolean(os.environ.get("REDASH_CLIENT_SIDE_METRICS",
 # Features:
 FEATURE_ALLOW_ALL_TO_EDIT_QUERIES = parse_boolean(os.environ.get("REDASH_FEATURE_ALLOW_ALL_TO_EDIT", "true"))
 FEATURE_TABLES_PERMISSIONS = parse_boolean(os.environ.get("REDASH_FEATURE_TABLES_PERMISSIONS", "false"))
+
+# BigQuery
+BIGQUERY_HTTP_TIMEOUT = int(os.environ.get("REDASH_BIGQUERY_HTTP_TIMEOUT", "600"))


### PR DESCRIPTION
We've noticed that sometimes calls to the BigQuery service hang, resulting eventually in all query runners stuck and not running queries. Added option to set timeout for BigQuery calls (with default being 10 minutes).