### PR TITLE
Feature: Support TreasureData as datasource

### DIFF
--- a/redash/query_runner/treasuredata.py
+++ b/redash/query_runner/treasuredata.py
@@ -1,0 +1,114 @@
+import json
+
+from redash.utils import JSONEncoder
+from redash.query_runner import *
+
+import logging
+logger = logging.getLogger(__name__)
+
+try:
+    import tdclient
+    enabled = True
+
+except ImportError:
+    logger.warning("Missing dependencies. Please install td-client.")
+    logger.warning("You can use pip: pip install td-client")
+    enabled = False
+
+TD_TYPES_MAPPING = {
+    'bigint': TYPE_INTEGER,
+    'tinyint': TYPE_INTEGER,
+    'smallint': TYPE_INTEGER,
+    'int': TYPE_INTEGER,
+    'integer': TYPE_INTEGER,
+    'long': TYPE_INTEGER,
+    'double': TYPE_FLOAT,
+    'decimal': TYPE_FLOAT,
+    'float': TYPE_FLOAT,
+    'real': TYPE_FLOAT,
+    'boolean': TYPE_BOOLEAN,
+    'timestamp': TYPE_DATETIME,
+    'date': TYPE_DATETIME,
+    'char': TYPE_STRING,
+    'string': TYPE_STRING,
+    'varchar': TYPE_STRING,
+}
+
+class TreasureData(BaseQueryRunner):
+    @classmethod
+    def configuration_schema(cls):
+        return {
+            'type': 'object',
+            'properties': {
+                'endpoint': {
+                    'type': 'string'
+                },
+                'apikey': {
+                    'type': 'string'
+                },
+                'type': {
+                    'type': 'string'
+                },
+                "db": {
+                    "type": "string",
+                    "title": "Database Name"
+                }
+            },
+            'required': ['apikey','db']
+        }
+
+    @classmethod
+    def enabled(cls):
+        return enabled
+
+    @classmethod
+    def annotate_query(cls):
+        return False
+
+    @classmethod
+    def type(cls):
+        return "treasuredata"
+
+    def __init__(self, configuration_json):
+        super(TreasureData, self).__init__(configuration_json)
+
+    def get_schema(self):
+        schema = {}
+        try:
+            with tdclient.Client(self.configuration.get('apikey')) as client:
+                for table in client.tables(self.configuration.get('db')):
+                    table_name = '{}.{}'.format(self.configuration.get('db'), table.name)
+                    for table_schema in table.schema:
+                        schema[table_name] = {'name': table_name, 'columns': table.schema}
+        except Exception, ex:
+            raise Exception("Failed getting schema")
+        return schema.values()
+
+    def run_query(self, query):
+        connection = tdclient.connect(
+                endpoint=self.configuration.get('endpoint', 'https://api.treasuredata.com'),
+                apikey=self.configuration.get('apikey'),
+                type=self.configuration.get('type', 'hive'),
+                db=self.configuration.get('db'))
+
+        cursor = connection.cursor()
+
+        try:
+            cursor.execute(query)
+            columns_data = [(row[0], cursor.show_job()['hive_result_schema'][i][1]) for i,row in enumerate(cursor.description)]
+
+            columns = [{'name': col[0],
+                'friendly_name': col[0],
+                'type': TD_TYPES_MAPPING.get(col[1], None)} for col in columns_data]
+
+            rows = [dict(zip(([c[0] for c in columns_data]), r)) for i, r in enumerate(cursor.fetchall())]
+            data = {'columns': columns, 'rows': rows}
+            json_data = json.dumps(data, cls=JSONEncoder)
+            error = None
+        except Exception, ex:
+            json_data = None
+            error = ex.message
+
+        return json_data, error
+
+register(TreasureData)

--- a/redash/settings.py
+++ b/redash/settings.py
@@ -126,7 +126,8 @@ QUERY_RUNNERS = array_from_string(os.environ.get("REDASH_ENABLED_QUERY_RUNNERS",
     'redash.query_runner.presto',
     'redash.query_runner.hive_ds',
     'redash.query_runner.impala_ds',
-    'redash.query_runner.vertica'
+    'redash.query_runner.vertica',
+    'redash.query_runner.treasuredata'
 ])))
 
 # Support for Sentry (http://getsentry.com/). Just set your Sentry DSN to enable it:

--- a/requirements_all_ds.txt
+++ b/requirements_all_ds.txt
@@ -8,3 +8,4 @@ pyhive==0.1.5
 pymongo==2.7.2
 pyOpenSSL==0.14
 vertica-python==0.5.1
+td-client==0.3.2


### PR DESCRIPTION
This PR is able to use TreasureData as new plugin.
[TreasureData](http://www.treasuredata.com/) is a simplified cloud analytics infrastructure like Redshift/BigQuery.
And, TreasureData doesn't provide visualization feature.
Through this PR, re:dash can issue Hive/Presto query to TreasureData.
Therefore, user can visualize own data on TreasureData easily by using re:dash.

This plugin needs [td-client-python](https://github.com/treasure-data/td-client-python)

- Add data source
![Add data source](https://i.gyazo.com/54748b21ceacc8133d12a8160f001039.png)

- New Query
![New Query](https://i.gyazo.com/bc1f677789a969995768765f4dbd95c8.png)

- Running job on TreasureData
![TreasureData](https://i.gyazo.com/b5e738258409a45994ae1f29ca32fed2.png)