### PR TITLE
Fix: support for duplicate columns for MySQL query runner

### DIFF
--- a/redash/query_runner/__init__.py
+++ b/redash/query_runner/__init__.py
@@ -79,7 +79,9 @@ class BaseQueryRunner(object):
                 duplicates_counter += 1
 
             column_names.append(column_name)
-            new_columns.append([column_name, col[1]])
+            new_columns.append({'name': column_name,
+                                'friendly_name': column_name,
+                                'type': col[1]})
 
         return new_columns
 

--- a/redash/query_runner/__init__.py
+++ b/redash/query_runner/__init__.py
@@ -75,7 +75,7 @@ class BaseQueryRunner(object):
         for col in columns:
             column_name = col[0]
             if column_name in column_names:
-                column_name += " " + str(duplicates_counter)
+                column_name = "{}_{}".format(column_name, duplicates_counter)
                 duplicates_counter += 1
 
             column_names.append(column_name)

--- a/redash/query_runner/__init__.py
+++ b/redash/query_runner/__init__.py
@@ -75,7 +75,7 @@ class BaseQueryRunner(object):
         for col in columns:
             column_name = col[0]
             if column_name in column_names:
-                column_name = "{}_{}".format(column_name, duplicates_counter)
+                column_name = "{}{}".format(column_name, duplicates_counter)
                 duplicates_counter += 1
 
             column_names.append(column_name)

--- a/redash/query_runner/__init__.py
+++ b/redash/query_runner/__init__.py
@@ -67,6 +67,22 @@ class BaseQueryRunner(object):
     def run_query(self, query):
         raise NotImplementedError()
 
+    def fetch_columns(self, columns):
+        column_names = []
+        duplicates_counter = 1
+        new_columns = []
+
+        for col in columns:
+            column_name = col[0]
+            if column_name in column_names:
+                column_name += " " + str(duplicates_counter)
+                duplicates_counter += 1
+
+            column_names.append(column_name)
+            new_columns.append([column_name, col[1]])
+
+        return new_columns
+
     def get_schema(self):
         return []
 

--- a/redash/query_runner/mysql.py
+++ b/redash/query_runner/mysql.py
@@ -119,13 +119,13 @@ class Mysql(BaseQueryRunner):
 
             # TODO - very similar to pg.py
             if cursor.description is not None:
-                columns_data = [(i[0], i[1]) for i in cursor.description]
+                columns_data = self.fetch_columns([(i[0], types_map.get(i[1], None)) for i in cursor.description])
 
                 rows = [dict(zip((c[0] for c in columns_data), row)) for row in data]
 
                 columns = [{'name': col[0],
                             'friendly_name': col[0],
-                            'type': types_map.get(col[1], None)} for col in columns_data]
+                            'type': col[1]} for col in columns_data]
 
                 data = {'columns': columns, 'rows': rows}
                 json_data = json.dumps(data, cls=JSONEncoder)

--- a/redash/query_runner/mysql.py
+++ b/redash/query_runner/mysql.py
@@ -119,13 +119,8 @@ class Mysql(BaseQueryRunner):
 
             # TODO - very similar to pg.py
             if cursor.description is not None:
-                columns_data = self.fetch_columns([(i[0], types_map.get(i[1], None)) for i in cursor.description])
-
-                rows = [dict(zip((c[0] for c in columns_data), row)) for row in data]
-
-                columns = [{'name': col[0],
-                            'friendly_name': col[0],
-                            'type': col[1]} for col in columns_data]
+                columns = self.fetch_columns([(i[0], types_map.get(i[1], None)) for i in cursor.description])
+                rows = [dict(zip((c['name'] for c in columns), row)) for row in data]
 
                 data = {'columns': columns, 'rows': rows}
                 json_data = json.dumps(data, cls=JSONEncoder)

--- a/redash/query_runner/pg.py
+++ b/redash/query_runner/pg.py
@@ -122,13 +122,8 @@ class PostgreSQL(BaseQueryRunner):
             _wait(connection)
 
             if cursor.description is not None:
-                columns_data = self.fetch_columns([(i.name, types_map.get(i.type_code, None)) for i in cursor.description])
-
-                columns = [{'name': col[0],
-                            'friendly_name': col[0],
-                            'type': col[1]} for col in columns_data]
-
-                rows = [dict(zip((c[0] for c in columns_data), row)) for row in cursor]
+                columns = self.fetch_columns([(i[0], types_map.get(i[1], None)) for i in cursor.description])
+                rows = [dict(zip((c['name'] for c in columns), row)) for row in cursor]
 
                 data = {'columns': columns, 'rows': rows}
                 error = None


### PR DESCRIPTION
This Pull Request fixes #571 issues with duplicated column names:

> If we have two columns with the same name in the same query the result is overridden. In this query I also found another bug: the `COUNT` and the `GROUP_CONCAT` does not show results if they don't have an alias.

This is my very first python code. All comments are welcome.