### PR TITLE
Fix: getKeyFromObject was failing if key had dot in name

### DIFF
--- a/rd_ui/app/scripts/ng_smart_table.js
+++ b/rd_ui/app/scripts/ng_smart_table.js
@@ -10,7 +10,7 @@ function getNestedValue (obj, keys) {
 function getKeyFromObject(obj, key) {
   var value = obj[key];
 
-  if ((!_.include(obj, key) && _.string.include(key, '.'))) {
+  if ((!_.has(obj, key) && _.string.include(key, '.'))) {
     var keys = key.split(".");
 
     value = getNestedValue(obj, keys);


### PR DESCRIPTION
This is due to incorrect use of `_.include` instead of `_.has`.

Ref: #571