### PR TITLE
Added "Select last used data source" to query view

### DIFF
--- a/rd_ui/app/scripts/controllers/query_view.js
+++ b/rd_ui/app/scripts/controllers/query_view.js
@@ -19,14 +19,35 @@
       $scope.queryResult = $scope.query.getQueryResult(maxAge, parameters);
     }
 
+    var getDataSourceId = function() {
+      // Try to get the query's data source id
+      var dataSourceId = $scope.query.data_source_id;
+
+      // If there is no source yet, then parse what we have in localStorage
+      //   e.g. `null` -> `NaN`, malformed data -> `NaN`, "1" -> 1
+      if (dataSourceId === undefined) {
+        dataSourceId = parseInt(localStorage.lastSelectedDataSourceId, 10);
+      }
+
+      // If we had an invalid value in localStorage (e.g. nothing, deleted source), then use the first data source
+      var isValidDataSourceId = !isNaN(dataSourceId) && _.some($scope.dataSources, function(ds) {
+        return ds.id == dataSourceId;
+      });
+      if (!isValidDataSourceId) {
+        dataSourceId = $scope.dataSources[0].id;
+      }
+
+      // Return our data source id
+      return dataSourceId;
+    }
+
     $scope.dataSource = {};
     $scope.query = $route.current.locals.query;
 
     var updateSchema = function() {
       $scope.hasSchema = false;
       $scope.editorSize = "col-md-12";
-      var dataSourceId = $scope.query.data_source_id || $scope.dataSources[0].id;
-      DataSource.getSchema({id: dataSourceId}, function(data) {
+      DataSource.getSchema({id: getDataSourceId()}, function(data) {
         if (data && data.length > 0) {
           $scope.schema = data;
           _.each(data, function(table) {
@@ -53,7 +74,7 @@
       updateSchema();
 
       if ($scope.query.isNew()) {
-        $scope.query.data_source_id = $scope.query.data_source_id || dataSources[0].id;
+        $scope.query.data_source_id = getDataSourceId();
         $scope.dataSource = _.find(dataSources, function(ds) { return ds.id == $scope.query.data_source_id; });
       }
     });
@@ -146,6 +167,7 @@
 
     $scope.updateDataSource = function() {
       Events.record(currentUser, 'update_data_source', 'query', $scope.query.id);
+      localStorage.lastSelectedDataSourceId = $scope.query.data_source_id;
 
       $scope.query.latest_query_data = null;
       $scope.query.latest_query_data_id = null;


### PR DESCRIPTION
We at Underdog.io are loving `redash` for setting up internal dashboards. We have 1 minor pain point which is `redash:metadata` is always selected as the first data source for a new query. While we could delete the `redash:metadata`, it would be really kicking the can down the road and not solving the problem.

We had an idea to re-use the selection that a user had from the last time they change the data source (e.g. if I use "db-a", then I will see "db-a" selected the next time I create a new query). This PR is working solution for that. In this PR:

- Added load/save `last_selected_data_source_id` in `localStorage` as part of `dataSourceId` interactions

**Notes:**

I am not too familiar with Angular so I wasn't sure if `localStorage` should be injected as a dependency. If you have any requests for how the code should be organized or about using library (e.g. `ded/kizzy`), please let me know.