### PR TITLE
Fix: don't send passwords back to the UI

### DIFF
--- a/rd_ui/app/views/data_sources/form.html
+++ b/rd_ui/app/views/data_sources/form.html
@@ -12,7 +12,7 @@
         <input name="input" type="{{input.type}}" class="form-control" ng-model="dataSource.options[name]" ng-required="input.required"
                 ng-if="input.type !== 'file'" accesskey="tab">
 
-        <input name="input" type="file" class="form-control" ng-model="files[name]" ng-required="input.required"
+        <input name="input" type="file" class="form-control" ng-model="files[name]" ng-required="input.required && !dataSource.options[name]"
                base-sixty-four-input
                ng-if="input.type === 'file'">
     </div>

--- a/redash/handlers/data_sources.py
+++ b/redash/handlers/data_sources.py
@@ -28,6 +28,9 @@ class DataSourceAPI(BaseResource):
     def post(self, data_source_id):
         data_source = models.DataSource.get_by_id(data_source_id)
         req = request.get_json(True)
+
+        data_source.replace_secret_placeholders(req['options'])
+
         if not validate_configuration(req['type'], req['options']):
             abort(400)
 

--- a/redash/query_runner/big_query.py
+++ b/redash/query_runner/big_query.py
@@ -97,7 +97,8 @@ class BigQuery(BaseQueryRunner):
                     'title': 'JSON Key File'
                 }
             },
-            'required': ['jsonKeyFile', 'projectId']
+            'required': ['jsonKeyFile', 'projectId'],
+            'secret': ['jsonKeyFile']
         }
 
     def __init__(self, configuration_json):

--- a/redash/query_runner/google_spreadsheets.py
+++ b/redash/query_runner/google_spreadsheets.py
@@ -96,7 +96,8 @@ class GoogleSpreadsheet(BaseQueryRunner):
                     'title': 'JSON Key File'
                 }
             },
-            'required': ['jsonKeyFile']
+            'required': ['jsonKeyFile'],
+            'secret': ['jsonKeyFile']
         }
 
     def __init__(self, configuration_json):

--- a/redash/query_runner/graphite.py
+++ b/redash/query_runner/graphite.py
@@ -44,7 +44,8 @@ class Graphite(BaseQueryRunner):
                     'title': 'Verify SSL certificate'
                 }
             },
-            'required': ['url']
+            'required': ['url'],
+            'secret': ['password']
         }
 
     @classmethod

--- a/redash/query_runner/impala_ds.py
+++ b/redash/query_runner/impala_ds.py
@@ -66,7 +66,8 @@ class Impala(BaseQueryRunner):
                     "type": "number"
                 }
             },
-            "required": ["host"]
+            "required": ["host"],
+            "secret": ["ldap_password"]
         }
 
     @classmethod

--- a/redash/query_runner/mysql.py
+++ b/redash/query_runner/mysql.py
@@ -50,7 +50,8 @@ class Mysql(BaseQueryRunner):
                     "type": "number"
                 },
             },
-            'required': ['db']
+            'required': ['db'],
+            'secret': ['passwd']
         }
 
     @classmethod

--- a/redash/query_runner/pg.py
+++ b/redash/query_runner/pg.py
@@ -67,7 +67,8 @@ class PostgreSQL(BaseQueryRunner):
                     "title": "Database Name"
                 }
             },
-            "required": ["dbname"]
+            "required": ["dbname"],
+            "secret": ["password"]
         }
 
     @classmethod

--- a/redash/query_runner/vertica.py
+++ b/redash/query_runner/vertica.py
@@ -51,7 +51,8 @@ class Vertica(BaseQueryRunner):
                     "type": "number"
                 },
             },
-            'required': ['database']
+            'required': ['database'],
+            'secret': ['password']
         }
 
     @classmethod

--- a/redash/settings.py
+++ b/redash/settings.py
@@ -66,8 +66,7 @@ DATABASE_CONFIG = parse_db_url(os.environ.get("REDASH_DATABASE_URL", "postgresql
 CELERY_BROKER = os.environ.get("REDASH_CELERY_BROKER", REDIS_URL)
 CELERY_BACKEND = os.environ.get("REDASH_CELERY_BACKEND", CELERY_BROKER)
 
-# The following enables periodic job (every 5 minutes) of removing unused query results. Behind this "feature flag" until
-# proved to be "safe".
+# The following enables periodic job (every 5 minutes) of removing unused query results.
 QUERY_RESULTS_CLEANUP_ENABLED = parse_boolean(os.environ.get("REDASH_QUERY_RESULTS_CLEANUP_ENABLED", "true"))
 
 AUTH_TYPE = os.environ.get("REDASH_AUTH_TYPE", "api_key")


### PR DESCRIPTION
Currently when you ask for data source options as an admin, it was sending back the full data source configuration, including passwords. In case you have multiple admins in your system or you're using re:dash without HTTPS (not recommended), it might be a security concern. 

This pull request changes this: it will send a placeholder instead of the password (or any other field defined as "secret").

Closes #554.