### PR TITLE
Feature: allow setting only the additional query runners you need

### DIFF
--- a/docs/datasources.rst
+++ b/docs/datasources.rst
@@ -182,9 +182,9 @@ VPN and with users you trust).
 
 Notes:
 
-1. For security, the python query runner is disabled by default.  
-   To enable, add redash.query_runner.python to the 
-   REDASH_ENABLED_QUERY_RUNNERS environmental variable.
+- For security, the python query runner is disabled by default.
+  To enable, add ``redash.query_runner.python`` to the ``REDASH_ADDITIONAL_QUERY_RUNNERS`` environmental variable. If you used
+  the bootstrap script, or one of the provided images, add to ``/opt/redash/.env`` file the line: ``export REDASH_ADDITIONAL_QUERY_RUNNERS=redash.query_runner.python``.
 
 
 Vertica

--- a/redash/query_runner/treasuredata.py
+++ b/redash/query_runner/treasuredata.py
@@ -11,8 +11,6 @@ try:
     enabled = True
 
 except ImportError:
-    logger.warning("Missing dependencies. Please install td-client.")
-    logger.warning("You can use pip: pip install td-client")
     enabled = False
 
 TD_TYPES_MAPPING = {
@@ -33,6 +31,7 @@ TD_TYPES_MAPPING = {
     'string': TYPE_STRING,
     'varchar': TYPE_STRING,
 }
+
 
 class TreasureData(BaseQueryRunner):
     @classmethod

--- a/redash/settings.py
+++ b/redash/settings.py
@@ -1,6 +1,7 @@
 import json
 import os
 import urlparse
+from funcy import distinct
 
 
 def parse_db_url(url):
@@ -113,7 +114,7 @@ ACCESS_CONTROL_REQUEST_METHOD = os.environ.get("REDASH_CORS_ACCESS_CONTROL_REQUE
 ACCESS_CONTROL_ALLOW_HEADERS = os.environ.get("REDASH_CORS_ACCESS_CONTROL_ALLOW_HEADERS", "Content-Type")
 
 # Query Runners
-QUERY_RUNNERS = array_from_string(os.environ.get("REDASH_ENABLED_QUERY_RUNNERS", ",".join([
+default_query_runners = [
     'redash.query_runner.big_query',
     'redash.query_runner.google_spreadsheets',
     'redash.query_runner.graphite',
@@ -128,7 +129,12 @@ QUERY_RUNNERS = array_from_string(os.environ.get("REDASH_ENABLED_QUERY_RUNNERS",
     'redash.query_runner.impala_ds',
     'redash.query_runner.vertica',
     'redash.query_runner.treasuredata'
-])))
+]
+
+enabled_query_runners = array_from_string(os.environ.get("REDASH_ENABLED_QUERY_RUNNERS", ",".join(default_query_runners)))
+additional_query_runners = array_from_string(os.environ.get("REDASH_ADDITIONAL_QUERY_RUNNERS", ""))
+
+QUERY_RUNNERS = distinct(enabled_query_runners + additional_query_runners)
 
 # Support for Sentry (http://getsentry.com/). Just set your Sentry DSN to enable it:
 SENTRY_DSN = os.environ.get("REDASH_SENTRY_DSN", "")


### PR DESCRIPTION
A bit easier way of enabling non default query runners, by creating an ENV variable with only them, instead of repeating all the default ones as well.