### PR TITLE
Improve timezone handling:

### DIFF
--- a/rd_ui/app/index.html
+++ b/rd_ui/app/index.html
@@ -200,7 +200,7 @@
 
 <script>
     // TODO: move currentUser & features to be an Angular service
-    var featureFlags = {{ features|safe }};
+    var clientConfig = {{ client_config|safe }};
     var currentUser = {{ user|safe }};
 
     currentUser.canEdit = function(object) {

--- a/rd_ui/app/scripts/app.js
+++ b/rd_ui/app/scripts/app.js
@@ -19,7 +19,7 @@ angular.module('redash', [
     'ngSanitize'
   ]).config(['$routeProvider', '$locationProvider', '$compileProvider', 'growlProvider', 'uiSelectConfig',
     function ($routeProvider, $locationProvider, $compileProvider, growlProvider, uiSelectConfig) {
-      if (featureFlags.clientSideMetrics) {
+      if (clientConfig.clientSideMetrics) {
         Bucky.setOptions({
           host: '/api/metrics'
         });

--- a/rd_ui/app/scripts/controllers/controllers.js
+++ b/rd_ui/app/scripts/controllers/controllers.js
@@ -3,7 +3,8 @@
     if (!value) {
       return "-";
     }
-    return value.toDate().toLocaleString();
+
+    return value.format(clientConfig.dateTimeFormat);
   };
 
   var QuerySearchCtrl = function($scope, $location, $filter, Events, Query) {
@@ -150,7 +151,7 @@
   }
 
   var MainCtrl = function ($scope, $location, Dashboard, notifications) {
-    if (featureFlags.clientSideMetrics) {
+    if (clientConfig.clientSideMetrics) {
       $scope.$on('$locationChangeSuccess', function(event, newLocation, oldLocation) {
         // This will be called once per actual page load.
         Bucky.sendPagePerformance();

--- a/rd_ui/app/scripts/controllers/query_source.js
+++ b/rd_ui/app/scripts/controllers/query_source.js
@@ -17,7 +17,7 @@
         saveQuery = $scope.saveQuery;
 
     $scope.sourceMode = true;
-    $scope.canEdit = currentUser.canEdit($scope.query) || featureFlags.allowAllToEditQueries;
+    $scope.canEdit = currentUser.canEdit($scope.query) || clientConfig.allowAllToEditQueries;
     $scope.isDirty = false;
 
     $scope.newVisualization = undefined;

--- a/rd_ui/app/scripts/filters.js
+++ b/rd_ui/app/scripts/filters.js
@@ -82,7 +82,7 @@ angular.module('redash.filters', []).
       }
 
       var html = marked(text);
-      if (featureFlags.allowScriptsInUserInput) {
+      if (clientConfig.allowScriptsInUserInput) {
         html = $sce.trustAsHtml(html);
       }
 

--- a/rd_ui/app/scripts/ng_highchart.js
+++ b/rd_ui/app/scripts/ng_highchart.js
@@ -56,7 +56,7 @@
         ;
 
         if (moment.isMoment(this.x)) {
-          var s = '<b>' + this.x.toDate().toLocaleString() + '</b>',
+          var s = '<b>' + this.x.format(clientConfig.dateTimeFormat) + '</b>',
               pointsCount = this.points.length;
 
           $.each(this.points, function (i, point) {
@@ -273,7 +273,7 @@
 
             var chartOptions = $.extend(true, {}, defaultOptions, chartsDefaults);
             chartOptions.plotOptions.series = {
-              turboThreshold: featureFlags.highChartsTurboThreshold
+              turboThreshold: clientConfig.highChartsTurboThreshold
             }
 
             // $timeout makes sure that this function invoked after the DOM ready. When draw/init

--- a/rd_ui/app/scripts/services/resources.js
+++ b/rd_ui/app/scripts/services/resources.js
@@ -43,10 +43,10 @@
             if (angular.isNumber(v)) {
               columnTypes[k] = 'float';
             } else if (_.isString(v) && v.match(/^\d{4}-\d{2}-\d{2}T/)) {
-              row[k] = moment(v);
+              row[k] = moment.utc(v);
               columnTypes[k] = 'datetime';
             } else if (_.isString(v) && v.match(/^\d{4}-\d{2}-\d{2}/)) {
-              row[k] = moment(v);
+              row[k] = moment.utc(v);
               columnTypes[k] = 'date';
             } else if (typeof(v) == 'object' && v !== null) {
               row[k] = JSON.stringify(v);

--- a/rd_ui/app/scripts/visualizations/table.js
+++ b/rd_ui/app/scripts/visualizations/table.js
@@ -79,14 +79,14 @@
               } else if (columnType === 'date') {
                 columnDefinition.formatFunction = function (value) {
                   if (value && moment.isMoment(value)) {
-                    return value.toDate().toLocaleDateString();
+                    return value.format(clientConfig.dateFormat);
                   }
                   return value;
                 };
               } else if (columnType === 'datetime') {
                 columnDefinition.formatFunction = function (value) {
                   if (value && moment.isMoment(value)) {
-                    return value.toDate().toLocaleString();
+                    return value.format(clientConfig.dateTimeFormat);
                   }
                   return value;
                 };

--- a/rd_ui/test/mocks/redash_mocks.js
+++ b/rd_ui/test/mocks/redash_mocks.js
@@ -1,4 +1,4 @@
-featureFlags = [];
+clientConfig = {};
 currentUser = {
   id: 1,
   name: 'John Mock',

--- a/redash/handlers/static.py
+++ b/redash/handlers/static.py
@@ -36,14 +36,16 @@ def index(**kwargs):
         'permissions': current_user.permissions
     }
 
-    features = {
+    client_config = {
         'clientSideMetrics': settings.CLIENT_SIDE_METRICS,
         'allowScriptsInUserInput': settings.ALLOW_SCRIPTS_IN_USER_INPUT,
-        'highChartsTurboThreshold': settings.HIGHCHARTS_TURBO_THRESHOLD
+        'highChartsTurboThreshold': settings.HIGHCHARTS_TURBO_THRESHOLD,
+        'dateFormat': settings.DATE_FORMAT,
+        'dateTimeFormat': "{0} HH:mm".format(settings.DATE_FORMAT)
     }
 
     return render_template("index.html", user=json.dumps(user), name=settings.NAME,
-                           features=json.dumps(features),
+                           client_config=json.dumps(client_config),
                            analytics=settings.ANALYTICS)
 
 

--- a/redash/settings.py
+++ b/redash/settings.py
@@ -143,6 +143,7 @@ ALLOW_SCRIPTS_IN_USER_INPUT = parse_boolean(os.environ.get("REDASH_ALLOW_SCRIPTS
 CLIENT_SIDE_METRICS = parse_boolean(os.environ.get("REDASH_CLIENT_SIDE_METRICS", "false"))
 # http://api.highcharts.com/highcharts#plotOptions.series.turboThreshold
 HIGHCHARTS_TURBO_THRESHOLD = int(os.environ.get("REDASH_HIGHCHARTS_TURBO_THRESHOLD", "1000"))
+DATE_FORMAT = os.environ.get("REDASH_DATE_FORMAT", "DD/MM/YY")
 
 # Features:
 FEATURE_ALLOW_ALL_TO_EDIT_QUERIES = parse_boolean(os.environ.get("REDASH_FEATURE_ALLOW_ALL_TO_EDIT", "true"))


### PR DESCRIPTION
1. Load all date/datetime values with `moment.utc()` instead of `moment()`, which was assuming user's local timezone when time zone information wasn't available. 
2. Don't use `toLocaleString` to format strings (which was converting them to current timezone as well). Due to the need to allow showing dates with different formatting (DD/MM vs. MM/DD), there is a new setting to define the date format.

Ideally we should add a setting to the user's profile to allow him to select his default timezone and date/time format, which we can than use when showing timestamps.

Closes #411.