### PR TITLE
Feature: support MySQL over SSL

### DIFF
--- a/rd_ui/app/scripts/directives/data_source_directives.js
+++ b/rd_ui/app/scripts/directives/data_source_directives.js
@@ -49,6 +49,10 @@
                 prop.type = 'file';
               }
 
+              if (prop.type == 'boolean') {
+                prop.type = 'checkbox';
+              }
+
               prop.required = _.contains(type.configuration_schema.required, name);
             });
           });

--- a/redash/query_runner/mysql.py
+++ b/redash/query_runner/mysql.py
@@ -46,9 +46,25 @@ class Mysql(BaseQueryRunner):
                     'type': 'string',
                     'title': 'Database name'
                 },
-                "port": {
-                    "type": "number"
+                'port': {
+                    'type': 'number'
                 },
+                'use_ssl': {
+                    'type': 'boolean',
+                    'title': 'Use SSL'
+                },
+                'ssl_cacert': {
+                    'type': 'string',
+                    'title': 'CA certificate to verify peer against (SSL)'
+                },
+                'ssl_cert': {
+                    'type': 'string',
+                    'title': 'Client certificate file (SSL)'
+                },
+                'ssl_key': {
+                    'type': 'string',
+                    'title': 'Private key filename (SSL)'
+                }
             },
             'required': ['db'],
             'secret': ['passwd']
@@ -111,7 +127,8 @@ class Mysql(BaseQueryRunner):
                                          passwd=self.configuration.get('passwd', ''),
                                          db=self.configuration['db'],
                                          port=self.configuration.get('port', 3306),
-                                         charset='utf8', use_unicode=True)
+                                         charset='utf8', use_unicode=True,
+                                         ssl=self._get_ssl_parameters())
             cursor = connection.cursor()
             logger.debug("MySQL running query: %s", query)
             cursor.execute(query)
@@ -144,5 +161,20 @@ class Mysql(BaseQueryRunner):
                 connection.close()
 
         return json_data, error
+
+    def _get_ssl_parameters(self):
+        ssl_params = {}
+
+        if self.configuration.get('use_ssl'):
+            config_map = dict(ssl_cacert='ca',
+                              ssl_cert='cert',
+                              ssl_key='key')
+            for key, cfg in config_map.items():
+                val = self.configuration.get(key)
+                if val:
+                    ssl_params[cfg] = val
+
+        return ssl_params
+
 
 register(Mysql)

--- a/redash/query_runner/mysql.py
+++ b/redash/query_runner/mysql.py
@@ -55,15 +55,15 @@ class Mysql(BaseQueryRunner):
                 },
                 'ssl_cacert': {
                     'type': 'string',
-                    'title': 'CA certificate to verify peer against (SSL)'
+                    'title': 'Path to CA certificate file to verify peer against (SSL)'
                 },
                 'ssl_cert': {
                     'type': 'string',
-                    'title': 'Client certificate file (SSL)'
+                    'title': 'Path to client certificate file (SSL)'
                 },
                 'ssl_key': {
                     'type': 'string',
-                    'title': 'Private key filename (SSL)'
+                    'title': 'Path to private key file (SSL)'
                 }
             },
             'required': ['db'],


### PR DESCRIPTION
This PR allows an admin to use MySQL over SSL. Also fixes a bug where boolean values in the data sources tables would not be properly saved; a checkbox is now used to ensure the `true` or `false` values are properly sent.

![image](https://cloud.githubusercontent.com/assets/963826/10653017/2d21b8fc-7810-11e5-8e1a-59ffaa235c2b.png)

Suggestion: the configuration schema should use an `OrderedDict` so that the options don't appear out of order as above.


