### PR TITLE
Reverted pivottable upgrade to remove XSS vulnerability

### DIFF
--- a/rd_ui/app/index.html
+++ b/rd_ui/app/index.html
@@ -146,7 +146,6 @@
 <script src="/bower_components/gridster/dist/jquery.gridster.js"></script>
 <script src="/bower_components/angular-growl/build/angular-growl.js"></script>
 <script src="/bower_components/pivottable/dist/pivot.js"></script>
-<script src="/bower_components/pivottable/dist/export_renderers.js"></script>
 <script src="/bower_components/cornelius/src/cornelius.js"></script>
 <script src="/bower_components/mousetrap/mousetrap.js"></script>
 <script src="/bower_components/mousetrap/plugins/global-bind/mousetrap-global-bind.js"></script>

--- a/rd_ui/app/scripts/visualizations/pivot.js
+++ b/rd_ui/app/scripts/visualizations/pivot.js
@@ -19,10 +19,8 @@ renderers.directive('pivotTableRenderer', function () {
                     // We need to give the pivot table its own copy of the data, because its change
                     // it which interferes with other visualizations.
                     var data = $.extend(true, [], $scope.queryResult.getData());
-                    var renderers = $.extend($.pivotUtilities.renderers,
-                      $.pivotUtilities.export_renderers)
                     $(element).pivotUI(data, {
-                         renderers: renderers
+                         renderers: $.pivotUtilities.renderers
                     }, true);
                 }
             });

--- a/rd_ui/bower.json
+++ b/rd_ui/bower.json
@@ -15,7 +15,7 @@
     "codemirror": "4.8.0",
     "highcharts": "3.0.10",
     "underscore": "1.5.1",
-    "pivottable": "1.6.3",
+    "pivottable": "~1.1.1",
     "cornelius": "https://github.com/restorando/cornelius.git",
     "gridster": "0.2.0",
     "mousetrap": "~1.4.6",


### PR DESCRIPTION
For the past week, we have had some HackerOne researchers attacking our system. On Monday, we discovered an XSS attack that was dormant in our database was running inside of `redash`. The most simplified example I can give is a PostgreSQL query:

```sql
SELECT '<script>alert(1)</script>';
```

When it's run, we see an `alert` popup on the page (scary):

![screen shot 2015-11-03 at 4 53 32 pm](https://cloud.githubusercontent.com/assets/902488/10924305/727f9622-824b-11e5-9c17-cac83b6efdbb.png)

After some sleuthing, we found out it came from a `pivottable` upgrade between `v0.8.1-rc` and `v0.8.1.b1110`. During `pivottable@1.4.0`, they introduced better localization support but moved to HTML methods. We have submitted a PR to resolve this:

https://github.com/nicolaskruchten/pivottable/pull/401

In order to get everyone back to a non-vulnerable state ASAP, we suggest either:

- Downgrading everyone to `v0.8.0`
- Revert `pivottable` upgrade (until the PR is landed/released)
    - On average, it's 1 day turnaround but there is a wide distribution with outliers up to 9 months
    - http://issuestats.com/github/nicolaskruchten/pivottable

This PR takes the care of the latter option:

- Reverted commit that introduced `pivottable@1.6.3` upgrade and removes new exporters
    - https://github.com/EverythingMe/redash/commit/6cccd30553a129dcca19a44c64811fd670a741a6