### PR TITLE
Removed `rd-hidden-xs` to make everything visible on mobile

### DIFF
--- a/rd_ui/app/styles/redash.css
+++ b/rd_ui/app/styles/redash.css
@@ -432,16 +432,6 @@ div.table-name {
     padding: 30px;
 }
 
-/*
-bootstrap's hidden-xs class adds display:block when not hidden
-use this class when you need to keep the original display value
-*/
-@media (max-width: 767px) {
-    .rd-hidden-xs {
-        display: none !important;
-    }
-}
-
 .log-container {
     margin-bottom: 50px;
 }

--- a/rd_ui/app/views/query.html
+++ b/rd_ui/app/views/query.html
@@ -26,7 +26,7 @@
                 </div>
 
                 <div class="col-lg-2">
-                    <div class="rd-hidden-xs pull-right">
+                    <div class="pull-right">
                         <query-source-link></query-source-link>
                     </div>
                 </div>
@@ -68,7 +68,7 @@
                     </button>
                     <query-formatter></query-formatter>
                     <span class="pull-right">
-                        <button class="btn btn-xs btn-default rd-hidden-xs" ng-click="duplicateQuery()">
+                        <button class="btn btn-xs btn-default" ng-click="duplicateQuery()">
                             <span class="glyphicon glyphicon-share-alt"></span> Fork
                         </button>
 
@@ -103,7 +103,7 @@
     </div>
     <hr ng-if="sourceMode">
     <div class="row">
-        <div class="col-lg-3 rd-hidden-xs">
+        <div class="col-lg-3">
             <p>
                 <span class="glyphicon glyphicon-user"></span>
                 <span class="text-muted">Created By </span>
@@ -148,7 +148,7 @@
             <p>
                 <a class="btn btn-primary btn-sm" ng-disabled="queryExecuting || !queryResult.getData()" query-result-link target="_self">
                     <span class="glyphicon glyphicon-cloud-download"></span>
-                    <span class="rd-hidden-xs">Download Dataset</span>
+                    <span>Download Dataset</span>
                 </a>
 
                 <a class="btn btn-warning btn-sm" ng-disabled="queryExecuting" data-toggle="modal" data-target="#archive-confirmation-modal"


### PR DESCRIPTION
After discussion in #626, we decided to move forward to a PR for removing `rd-hidden-xs` (although the visuals here probably need approval). This enables actions on mobile which were hidden for unknown reasons (e.g. selecting a database, forking a query).

In this PR:

- Removed `rd-hidden-xs` from HTML and CSS

Here are visual changes:

**Before:**

![screen shot 2015-11-05 at 6 58 51 pm](https://cloud.githubusercontent.com/assets/902488/10986397/518a590c-83ef-11e5-8e6f-f9371a4164fb.png)
![screen shot 2015-11-05 at 6 59 07 pm](https://cloud.githubusercontent.com/assets/902488/10986396/518a17f8-83ef-11e5-8ac3-b42e17ae13b6.png)

**After:**

![screen shot 2015-11-05 at 6 52 00 pm](https://cloud.githubusercontent.com/assets/902488/10986381/3895fdca-83ef-11e5-9588-cf84a62476e7.png)
![screen shot 2015-11-05 at 6 52 04 pm](https://cloud.githubusercontent.com/assets/902488/10986382/389a9772-83ef-11e5-9017-4047a8c80b5a.png)

