### PR TITLE
Feature: permission to schedule query

### DIFF
--- a/migrations/0015_add_schedule_query_permission.py
+++ b/migrations/0015_add_schedule_query_permission.py
@@ -1,0 +1,6 @@
+from redash import models
+
+if __name__ == '__main__':
+    default_group = models.Group.get(models.Group.name=='default')
+    default_group.permissions.append('schedule_query')
+    default_group.save()

--- a/rd_ui/app/scripts/controllers/query_view.js
+++ b/rd_ui/app/scripts/controllers/query_view.js
@@ -70,6 +70,7 @@
     $scope.isQueryOwner = (currentUser.id === $scope.query.user.id) || currentUser.hasPermission('admin');
     $scope.canViewSource = currentUser.hasPermission('view_source');
     $scope.canExecuteQuery = currentUser.hasPermission('execute_query');
+    $scope.canScheduleQuery = currentUser.hasPermission('schedule_query');
 
     $scope.dataSources = DataSource.query(function(dataSources) {
       updateSchema();
@@ -240,7 +241,7 @@
     });
 
     $scope.openScheduleForm = function() {
-      if (!$scope.isQueryOwner) {
+      if (!$scope.isQueryOwner || !$scope.canScheduleQuery) {
         return;
       };
 

--- a/redash/models.py
+++ b/redash/models.py
@@ -131,7 +131,7 @@ class ApiUser(UserMixin, PermissionsCheckMixin):
 
 class Group(BaseModel):
     DEFAULT_PERMISSIONS = ['create_dashboard', 'create_query', 'edit_dashboard', 'edit_query',
-                           'view_query', 'view_source', 'execute_query', 'list_users']
+                           'view_query', 'view_source', 'execute_query', 'list_users', 'schedule_query']
 
     id = peewee.PrimaryKeyField()
     name = peewee.CharField(max_length=100)


### PR DESCRIPTION
We had a problem on Redshift where people were scheduling really expensive queries and slowing down our whole cluster. This allows us to whitelist particular users with the ability to schedule queries.