### PR TITLE
Fix: bind Redis to localhost

### DIFF
--- a/setup/files/redis.conf
+++ b/setup/files/redis.conf
@@ -62,7 +62,7 @@ tcp-backlog 511
 # Examples:
 #
 # bind 192.168.1.100 10.0.0.1
-# bind 127.0.0.1
+bind 127.0.0.1
 
 # Specify the path for the Unix socket that will be used to listen for
 # incoming connections. There is no default, so Redis will not listen


### PR DESCRIPTION
Having it bound to the public addresses is a security problem.
See http://antirez.com/news/96