### PR TITLE
Support default values in data source creation forms

### DIFF
--- a/rd_ui/app/views/data_sources/form.html
+++ b/rd_ui/app/views/data_sources/form.html
@@ -10,7 +10,7 @@
     <div class="form-group" ng-class='{"has-error": !inner.input.$valid}' ng-form="inner" ng-repeat="(name, input) in type.configuration_schema.properties">
         <label>{{input.title || name | capitalize}}</label>
         <input name="input" type="{{input.type}}" class="form-control" ng-model="dataSource.options[name]" ng-required="input.required"
-                ng-if="input.type !== 'file'" accesskey="tab">
+                ng-if="input.type !== 'file'" accesskey="tab" placeholder="{{input.default}}">
 
         <input name="input" type="file" class="form-control" ng-model="files[name]" ng-required="input.required && !dataSource.options[name]"
                base-sixty-four-input

--- a/redash/query_runner/mysql.py
+++ b/redash/query_runner/mysql.py
@@ -33,7 +33,8 @@ class Mysql(BaseQueryRunner):
             'type': 'object',
             'properties': {
                 'host': {
-                    'type': 'string'
+                    'type': 'string',
+                    'default': '127.0.0.1'
                 },
                 'user': {
                     'type': 'string'
@@ -47,7 +48,8 @@ class Mysql(BaseQueryRunner):
                     'title': 'Database name'
                 },
                 'port': {
-                    'type': 'number'
+                    'type': 'number',
+                    'default': 3306,
                 },
                 'use_ssl': {
                     'type': 'boolean',

--- a/redash/query_runner/pg.py
+++ b/redash/query_runner/pg.py
@@ -57,10 +57,12 @@ class PostgreSQL(BaseQueryRunner):
                     "type": "string"
                 },
                 "host": {
-                    "type": "string"
+                    "type": "string",
+                    "default": "127.0.0.1"
                 },
                 "port": {
-                    "type": "number"
+                    "type": "number",
+                    "default": 5432
                 },
                 "dbname": {
                     "type": "string",


### PR DESCRIPTION
The default values simply fill the input's placeholder. No value is actually set to the scope nor sent to the server.
When setting default values they should actually reflect the default behaviour of the data sources.

The use case for this feature is to let users understand what values are used by a data source in case a field isn't required (for example, mysql and postgres would connect to 127.0.0.1 if not value is specified in hostname)